### PR TITLE
add example on creating registration status event listener

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicIntegrationTests.kt
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicIntegrationTests.kt
@@ -402,10 +402,11 @@ class CampaignClassicIntegrationTests {
         }
 
         Assert.assertFalse(countDownLatch.await(1, TimeUnit.SECONDS))
-        // verify no registration status event dispatched
+        // verify registration status event dispatched with status false
         Thread.sleep(250)
         val registrationStatusEvents = MonitorExtension.getCapturedRegistrationEvents()
-        Assert.assertEquals(0, registrationStatusEvents.size)
+        Assert.assertEquals(1, registrationStatusEvents.size)
+        Assert.assertEquals(false, registrationStatusEvents.get(0).registrationStatus)
     }
 
     @Test
@@ -436,10 +437,11 @@ class CampaignClassicIntegrationTests {
         }
 
         Assert.assertFalse(countDownLatch.await(1, TimeUnit.SECONDS))
-        // verify no registration status event dispatched
+        // verify registration status event dispatched with status false
         Thread.sleep(250)
         val registrationStatusEvents = MonitorExtension.getCapturedRegistrationEvents()
-        Assert.assertEquals(0, registrationStatusEvents.size)
+        Assert.assertEquals(1, registrationStatusEvents.size)
+        Assert.assertEquals(false, registrationStatusEvents.get(0).registrationStatus)
     }
 
     @Test
@@ -470,10 +472,11 @@ class CampaignClassicIntegrationTests {
         }
 
         Assert.assertFalse(countDownLatch.await(1, TimeUnit.SECONDS))
-        // verify no registration status event dispatched
+        // verify registration status event dispatched with status false
         Thread.sleep(250)
         val registrationStatusEvents = MonitorExtension.getCapturedRegistrationEvents()
-        Assert.assertEquals(0, registrationStatusEvents.size)
+        Assert.assertEquals(1, registrationStatusEvents.size)
+        Assert.assertEquals(false, registrationStatusEvents.get(0).registrationStatus)
     }
 
     @Test
@@ -504,10 +507,11 @@ class CampaignClassicIntegrationTests {
         }
 
         Assert.assertFalse(countDownLatch.await(1, TimeUnit.SECONDS))
-        // verify no registration status event dispatched
+        // verify registration status event dispatched with status false
         Thread.sleep(250)
         val registrationStatusEvents = MonitorExtension.getCapturedRegistrationEvents()
-        Assert.assertEquals(0, registrationStatusEvents.size)
+        Assert.assertEquals(1, registrationStatusEvents.size)
+        Assert.assertEquals(false, registrationStatusEvents.get(0).registrationStatus)
     }
 
     @Test
@@ -612,10 +616,11 @@ class CampaignClassicIntegrationTests {
                 null
             )
         )
-        // verify no registration status event dispatched
+        // verify registration status event dispatched with status true as previous registration with same data was successful
         Thread.sleep(250)
         registrationStatusEvents = MonitorExtension.getCapturedRegistrationEvents()
-        Assert.assertEquals(0, registrationStatusEvents.size)
+        Assert.assertEquals(1, registrationStatusEvents.size)
+        Assert.assertEquals(true, registrationStatusEvents.get(0).registrationStatus)
     }
 
     @Test

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/RegistrationManager.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/RegistrationManager.kt
@@ -277,12 +277,11 @@ internal class RegistrationManager {
         )
 
         // send registration request
-        var registrationSuccessful = false
         Log.trace(CampaignClassicConstants.LOG_TAG, SELF_TAG, "sendRegistrationRequest - Registration request was sent with url $requestUrl")
         networkService.connectAsync(networkRequest) {
             if (it.responseCode == HttpURLConnection.HTTP_OK) {
                 Log.debug(CampaignClassicConstants.LOG_TAG, SELF_TAG, "sendRegistrationRequest - Registration successful.")
-                registrationSuccessful = true
+                dispatchRegistrationStatus(true)
                 updateDataStoreWithRegistrationInfo(registrationHash)
             } else {
                 Log.debug(
@@ -290,10 +289,10 @@ internal class RegistrationManager {
                     SELF_TAG,
                     "sendRegistrationRequest - Unsuccessful Registration request with connection status ${it.responseCode}"
                 )
+                dispatchRegistrationStatus(false)
             }
             it.close()
         }
-        dispatchRegistrationStatus(registrationSuccessful)
     }
 
     private fun dispatchRegistrationStatus(registrationStatus: Boolean) {

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/RegistrationManager.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/RegistrationManager.kt
@@ -89,6 +89,7 @@ internal class RegistrationManager {
                 "registerDevice - Failed to process device registration request," +
                     "device token is not available."
             )
+            dispatchRegistrationStatus(false)
             return
         }
 
@@ -101,6 +102,7 @@ internal class RegistrationManager {
                 "registerDevice - Failed to process device registration request," +
                     "MobilePrivacyStatus is not optedIn."
             )
+            dispatchRegistrationStatus(false)
             return
         }
 
@@ -112,6 +114,7 @@ internal class RegistrationManager {
                 "registerDevice - Failed to process device registration request," +
                     "Marketing server is not configured."
             )
+            dispatchRegistrationStatus(false)
             return
         }
 
@@ -122,6 +125,7 @@ internal class RegistrationManager {
                 "registerDevice - Failed to process device registration request," +
                     "Integration key is not configured."
             )
+            dispatchRegistrationStatus(false)
             return
         }
 
@@ -160,6 +164,7 @@ internal class RegistrationManager {
                 "registerDevice - Not sending device registration request," +
                     "there is no change in registration info."
             )
+            dispatchRegistrationStatus(true)
             return
         }
 
@@ -262,6 +267,7 @@ internal class RegistrationManager {
                 SELF_TAG,
                 "sendRegistrationRequest - Cannot send request, Network service is not available."
             )
+            dispatchRegistrationStatus(false)
             return
         }
 

--- a/code/testapp/src/main/java/com/adobe/campaignclassictestapp/CampaignClassicTestApp.java
+++ b/code/testapp/src/main/java/com/adobe/campaignclassictestapp/CampaignClassicTestApp.java
@@ -2,10 +2,12 @@ package com.adobe.campaignclassictestapp;
 
 import com.adobe.marketing.mobile.AdobeCallback;
 import com.adobe.marketing.mobile.CampaignClassic;
+import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.EventSource;
+import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.LoggingMode;
-import com.adobe.marketing.mobile.MobilePrivacyStatus;
 
 import android.app.Application;
 import android.util.Log;
@@ -29,6 +31,13 @@ public class CampaignClassicTestApp extends Application {
 				@Override
 				public void call(Object o) {
 					MobileCore.configureWithAppID("");
+					// test campaign response event dispatch
+					MobileCore.registerEventListener(EventType.CAMPAIGN, EventSource.RESPONSE_CONTENT, new AdobeCallback<Event>() {
+						@Override
+						public void call(Event event) {
+							Log.d("ACCRegistrationStatus", event.getEventData().get("registrationstatus").toString());
+						}
+					});
 				}
 			});
 			Thread.sleep(1000);

--- a/code/testapp/src/main/java/com/adobe/campaignclassictestapp/CampaignClassicTestApp.java
+++ b/code/testapp/src/main/java/com/adobe/campaignclassictestapp/CampaignClassicTestApp.java
@@ -31,7 +31,7 @@ public class CampaignClassicTestApp extends Application {
 				@Override
 				public void call(Object o) {
 					MobileCore.configureWithAppID("");
-					// test campaign response event dispatch
+					// listen for campaign response event
 					MobileCore.registerEventListener(EventType.CAMPAIGN, EventSource.RESPONSE_CONTENT, new AdobeCallback<Event>() {
 						@Override
 						public void call(Event event) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- also dispatch event within connectAsync callback to prevent a race condition with the registration status response event being dispatched before the connection is completed.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
