### PR TITLE
add handling for existing ACC legacy and http v1 payloads

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.0.1";
+    static final String EXTENSION_VERSION = "2.1.0";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPMessagingService.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPMessagingService.java
@@ -107,8 +107,10 @@ public class AEPMessagingService extends FirebaseMessagingService {
      * @return {@code boolean} signaling if the {@link AEPMessagingService} handled the remote
      *     message
      */
+    // TODO: added for testing only, will be removed in the future
     @VisibleForTesting
-    public static boolean handleRemoteMessageData(
+    // public
+    static boolean handleRemoteMessageData(
             @NonNull final Context context, @NonNull final Map<String, String> messageData) {
         final NotificationManagerCompat notificationManager =
                 NotificationManagerCompat.from(context);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPMessagingService.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPMessagingService.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.NotificationManagerCompat;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.StringUtils;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.HashMap;
@@ -61,9 +62,15 @@ public class AEPMessagingService extends FirebaseMessagingService {
         AEPPushPayload payload;
         try {
             payload = new AEPPushPayload(remoteMessage);
+            // get the tag from the payload. if no tag was present in the payload use the message id
+            // instead as its guaranteed to always be present.
+            final String tag =
+                    !StringUtils.isNullOrEmpty(payload.getTag())
+                            ? payload.getTag()
+                            : payload.getMessageId();
             final Notification notification =
                     AEPPushNotificationBuilder.buildPushNotification(payload, context);
-            notificationManager.notify(payload.getMessageId().hashCode(), notification);
+            notificationManager.notify(tag.hashCode(), notification);
         } catch (final IllegalArgumentException exception) {
             Log.error(
                     CampaignPushConstants.LOG_TAG,
@@ -81,6 +88,9 @@ public class AEPMessagingService extends FirebaseMessagingService {
                     exception.getLocalizedMessage());
             return false;
         }
+
+        // call track notification receive as we know that the push payload data is valid
+        trackNotificationReceive(payload);
 
         return true;
     }
@@ -105,9 +115,15 @@ public class AEPMessagingService extends FirebaseMessagingService {
         AEPPushPayload payload;
         try {
             payload = new AEPPushPayload(messageData);
+            // get the tag from the payload. if no tag was present in the payload use the message id
+            // instead as its guaranteed to always be present.
+            final String tag =
+                    !StringUtils.isNullOrEmpty(payload.getTag())
+                            ? payload.getTag()
+                            : payload.getMessageId();
             final Notification notification =
                     AEPPushNotificationBuilder.buildPushNotification(payload, context);
-            notificationManager.notify(payload.getMessageId().hashCode(), notification);
+            notificationManager.notify(tag.hashCode(), notification);
         } catch (final IllegalArgumentException exception) {
             Log.error(
                     CampaignPushConstants.LOG_TAG,

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -153,9 +153,8 @@ class AEPPushNotificationBuilder {
                 Log.debug(
                         CampaignPushConstants.LOG_TAG,
                         SELF_TAG,
-                        "Channel does not exist for channel ID obtained from payload ( "
-                                + channelIdFromPayload
-                                + "). Using the Campaign Classic Extension's default channel.");
+                        "No channel ID obtained from payload. Using the Campaign Classic"
+                                + " Extension's default channel.");
             }
 
             // Use the default channel ID if the channel ID from the payload is null or if a channel
@@ -164,13 +163,14 @@ class AEPPushNotificationBuilder {
                 Log.debug(
                         CampaignPushConstants.LOG_TAG,
                         SELF_TAG,
-                        "Channel already exists for the default channel ID: " + channelId);
-                return DEFAULT_CHANNEL_ID;
+                        "Channel already exists for the default channel ID: " + DEFAULT_CHANNEL_ID);
             } else {
                 Log.debug(
                         CampaignPushConstants.LOG_TAG,
                         SELF_TAG,
-                        "Creating a new channel for the default channel ID: " + channelId + ".");
+                        "Creating a new channel for the default channel ID: "
+                                + DEFAULT_CHANNEL_ID
+                                + ".");
                 final NotificationChannel channel =
                         new NotificationChannel(
                                 DEFAULT_CHANNEL_ID, DEFAULT_CHANNEL_NAME, importance);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -47,6 +47,7 @@ class AEPPushNotificationBuilder {
     // used.
     // This will appear in the notification settings for the app.
     private static final String DEFAULT_CHANNEL_NAME = "Campaign Classic General Notifications";
+    private static final String SILENT_CHANNEL_NAME = "Campaign Classic Silent Notifications";
 
     /**
      * Builds a notification for the provided {@code AEPPushPayload}.
@@ -192,7 +193,7 @@ class AEPPushNotificationBuilder {
         final NotificationChannel silentChannel =
                 new NotificationChannel(
                         CampaignPushConstants.DefaultValues.SILENT_NOTIFICATION_CHANNEL_ID,
-                        DEFAULT_CHANNEL_NAME,
+                        SILENT_CHANNEL_NAME,
                         importance);
 
         // set no sound on the silent channel
@@ -272,29 +273,17 @@ class AEPPushNotificationBuilder {
 
     /**
      * Sets the sound for the notification. If a sound is received from the payload, the same is
-     * used. If a sound is not received from the payload, the default sound is used The sound name
-     * from the payload should also include the format of the sound file. eg: sound.mp3
+     * used. If a sound is not received from the payload, the default sound is used.
      *
      * @param context the application {@link Context}
      * @param notificationBuilder the notification builder
      * @param customSound {@code String} containing the custom sound file name to load from the
      *     bundled assets
-     * @param isSilent {@code boolean} signaling if a silent sound should be assigned to the
-     *     provided {@code NotificationCompat.Builder}
      */
     static void setSound(
             final Context context,
             final NotificationCompat.Builder notificationBuilder,
-            final String customSound,
-            final boolean isSilent) {
-        if (isSilent) {
-            Log.trace(
-                    CampaignPushConstants.LOG_TAG,
-                    SELF_TAG,
-                    "Setting a silent sound on the notification.");
-            notificationBuilder.setSound(null);
-            return;
-        }
+            final String customSound) {
 
         if (StringUtils.isNullOrEmpty(customSound)) {
             Log.trace(
@@ -319,15 +308,12 @@ class AEPPushNotificationBuilder {
     /**
      * Sets the sound for the provided {@code NotificationChannel}. If a sound is received from the
      * payload, the same is used. If a sound is not received from the payload, the default sound is
-     * used. The sound name from the payload should also include the format of the sound file. eg:
-     * sound.mp3
+     * used.
      *
      * @param context the application {@link Context}
      * @param notificationChannel the {@link NotificationChannel} to assign the sound to
      * @param customSound {@code String} containing the custom sound file name to load from the
      *     bundled assets
-     * @param isSilent {@code boolean} signaling if a silent sound should be assigned to the
-     *     provided {@code NotificationChannel}
      */
     static void setSound(
             final Context context,
@@ -342,8 +328,7 @@ class AEPPushNotificationBuilder {
             Log.trace(
                     CampaignPushConstants.LOG_TAG,
                     SELF_TAG,
-                    "Setting a silent sound on channel named %s.",
-                    notificationChannel.getName());
+                    "Creating a silent notification channel.");
             notificationChannel.setSound(null, null);
             return;
         }

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -61,8 +61,11 @@ class AEPPushNotificationBuilder {
         NotificationCompat.Builder builder;
         final Map<String, String> messageData = payload.getMessageData();
         final PushTemplateType pushTemplateType =
-                PushTemplateType.fromString(
-                        messageData.get(CampaignPushConstants.PushPayloadKeys.TEMPLATE_TYPE));
+                messageData.get(CampaignPushConstants.PushPayloadKeys.TEMPLATE_TYPE) == null
+                        ? PushTemplateType.UNKNOWN
+                        : PushTemplateType.fromString(
+                                messageData.get(
+                                        CampaignPushConstants.PushPayloadKeys.TEMPLATE_TYPE));
         switch (pushTemplateType) {
             case BASIC:
                 final BasicPushTemplate basicPushTemplate = new BasicPushTemplate(messageData);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushPayload.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushPayload.java
@@ -11,20 +11,56 @@
 package com.adobe.marketing.mobile;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
 import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import com.google.firebase.messaging.RemoteMessage;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  * This class validates then stores the {@link Map<String, String>} message data contained in the
  * provided {@link RemoteMessage}.
  */
-public class AEPPushPayload {
+class AEPPushPayload {
     private Map<String, String> messageData;
     private String messageId;
     private String deliveryId;
     private String tag;
+    private static final Map<Integer, String> notificationCompatPriorityMap =
+            new HashMap<Integer, String>() {
+                {
+                    put(
+                            NotificationCompat.PRIORITY_MIN,
+                            AEPPushTemplate.NotificationPriority.PRIORITY_MIN);
+                    put(
+                            NotificationCompat.PRIORITY_LOW,
+                            AEPPushTemplate.NotificationPriority.PRIORITY_LOW);
+                    put(
+                            NotificationCompat.PRIORITY_DEFAULT,
+                            AEPPushTemplate.NotificationPriority.PRIORITY_DEFAULT);
+                    put(
+                            NotificationCompat.PRIORITY_HIGH,
+                            AEPPushTemplate.NotificationPriority.PRIORITY_HIGH);
+                    put(
+                            NotificationCompat.PRIORITY_MAX,
+                            AEPPushTemplate.NotificationPriority.PRIORITY_MAX);
+                }
+            };
+    private static final Map<Integer, String> notificationCompatVisibilityMap =
+            new HashMap<Integer, String>() {
+                {
+                    put(
+                            NotificationCompat.VISIBILITY_PRIVATE,
+                            AEPPushTemplate.NotificationVisibility.PRIVATE);
+                    put(
+                            NotificationCompat.VISIBILITY_PUBLIC,
+                            AEPPushTemplate.NotificationVisibility.PUBLIC);
+                    put(
+                            NotificationCompat.VISIBILITY_SECRET,
+                            AEPPushTemplate.NotificationVisibility.SECRET);
+                }
+            };
 
     /**
      * Constructor
@@ -115,10 +151,10 @@ public class AEPPushPayload {
                 String.valueOf(notification.getSticky()));
         messageData.put(
                 CampaignPushConstants.PushPayloadKeys.NOTIFICATION_VISIBILITY,
-                String.valueOf(notification.getVisibility()));
+                notificationCompatVisibilityMap.get(notification.getVisibility()));
         messageData.put(
                 CampaignPushConstants.PushPayloadKeys.NOTIFICATION_PRIORITY,
-                String.valueOf(notification.getNotificationPriority()));
+                notificationCompatPriorityMap.get(notification.getNotificationPriority()));
         messageData.put(
                 CampaignPushConstants.PushPayloadKeys.BADGE_NUMBER,
                 String.valueOf(notification.getNotificationCount()));

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushPayload.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushPayload.java
@@ -72,7 +72,7 @@ class AEPPushPayload {
      * @throws IllegalArgumentException if the message, message data, message id, or delivery id is
      *     null
      */
-    public AEPPushPayload(final RemoteMessage message) throws IllegalArgumentException {
+    AEPPushPayload(final RemoteMessage message) throws IllegalArgumentException {
         if (message == null) {
             throw new IllegalArgumentException(
                     "Failed to create AEPPushPayload, remote message is null.");
@@ -95,7 +95,7 @@ class AEPPushPayload {
      *     notification received from {@link com.google.firebase.messaging.FirebaseMessagingService}
      * @throws IllegalArgumentException if the message data, message id, or delivery id is null
      */
-    public AEPPushPayload(final Map<String, String> messageData) throws IllegalArgumentException {
+    AEPPushPayload(final Map<String, String> messageData) throws IllegalArgumentException {
         validateMessageData(messageData);
     }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
@@ -141,6 +141,15 @@ class AEPPushTemplate {
     // Optional, If present, schedule this notification to be re-delivered at this epoch timestamp
     // (in seconds) provided.
     private final long remindLaterTimestamp;
+    // Optional, If present and a notification with the same tag is already being shown, the new
+    // notification replaces the existing one in the notification drawer.
+    private final String tag;
+    // Optional, If present sets the "ticker" text, which is sent to accessibility services.
+    private final String ticker;
+    // Optional, when set to false or unset, the notification is automatically dismissed when the
+    // user clicks it in the panel. When set to true, the notification persists even when the user
+    // clicks it.
+    private final boolean sticky;
 
     @RequiresApi(api = Build.VERSION_CODES.N)
     static final Map<String, Integer> notificationImportanceMap =
@@ -254,10 +263,17 @@ class AEPPushTemplate {
                 StringUtils.isNullOrEmpty(timestampString)
                         ? CampaignPushConstants.DefaultValues.DEFAULT_REMIND_LATER_TIMESTAMP
                         : Long.parseLong(timestampString);
+        this.tag = DataReader.optString(data, CampaignPushConstants.PushPayloadKeys.TAG, null);
+        this.ticker =
+                DataReader.optString(data, CampaignPushConstants.PushPayloadKeys.TICKER, null);
+        final String stickyValue =
+                DataReader.optString(data, CampaignPushConstants.PushPayloadKeys.STICKY, null);
+        this.sticky =
+                StringUtils.isNullOrEmpty(stickyValue) ? false : Boolean.parseBoolean(stickyValue);
 
         try {
             final String count = data.get(CampaignPushConstants.PushPayloadKeys.BADGE_NUMBER);
-            if (count != null) {
+            if (StringUtils.isNullOrEmpty(count)) {
                 this.badgeCount = Integer.parseInt(count);
             }
         } catch (final NumberFormatException e) {
@@ -366,6 +382,18 @@ class AEPPushTemplate {
 
     long getRemindLaterTimestamp() {
         return remindLaterTimestamp;
+    }
+
+    @Nullable String getNotificationTag() {
+        return tag;
+    }
+
+    @Nullable String getNotificationTicker() {
+        return ticker;
+    }
+
+    boolean getNotificationAutoCancel() {
+        return sticky;
     }
 
     /** @return an {@link AEPPushTemplate.ActionType} */

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
@@ -202,9 +202,18 @@ class AEPPushTemplate {
         }
 
         try {
-            this.body = DataReader.getString(data, CampaignPushConstants.PushPayloadKeys.BODY);
+            final String bodyText =
+                    DataReader.optString(
+                            data,
+                            CampaignPushConstants.PushPayloadKeys.BODY,
+                            DataReader.getString(
+                                    data, CampaignPushConstants.PushPayloadKeys.ACC_PAYLOAD_BODY));
+            if (StringUtils.isNullOrEmpty(bodyText)) {
+                throw new DataReaderException("Required field \"adb_body\" or \"_msg\" not found.");
+            }
+            this.body = bodyText;
         } catch (final DataReaderException dataReaderException) {
-            throw new IllegalArgumentException("Required field \"adb_body\" not found.");
+            throw new IllegalArgumentException(dataReaderException.getMessage());
         }
 
         try {
@@ -509,9 +518,9 @@ class AEPPushTemplate {
 
     @RequiresApi(api = Build.VERSION_CODES.N)
     private int getNotificationImportanceFromString(final String priority) {
-        if (StringUtils.isNullOrEmpty(priority)) return NotificationCompat.PRIORITY_DEFAULT;
+        if (StringUtils.isNullOrEmpty(priority)) return NotificationManager.IMPORTANCE_DEFAULT;
         final Integer resolvedImportance = notificationImportanceMap.get(priority);
-        if (resolvedImportance == null) return NotificationCompat.PRIORITY_DEFAULT;
+        if (resolvedImportance == null) return NotificationManager.IMPORTANCE_DEFAULT;
         return resolvedImportance;
     }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
@@ -85,23 +85,22 @@ class AutoCarouselTemplateNotificationBuilder {
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(context, channelId)
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setAutoCancel(true)
+                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
 
+        // small Icon must be present, otherwise the notification will not be displayed.
         AEPPushNotificationBuilder.setSmallIcon(
-                context,
-                builder,
-                pushTemplate.getIcon(),
-                pushTemplate.getSmallIconColor()); // Small Icon must be present, otherwise the
-        // notification will not be
-        // displayed.
+                context, builder, pushTemplate.getIcon(), pushTemplate.getSmallIconColor());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             AEPPushNotificationBuilder.setVisibility(
                     builder, pushTemplate.getNotificationVisibility());
         }
-        AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound(), false);
+
+        // set custom sound, note this applies to API 25 and lower only as API 26 and up set the
+        // sound on the notification channel
+        AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound());
 
         // if API level is below 26 (prior to notification channels) then notification priority is
         // set on the notification builder

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
@@ -103,6 +103,9 @@ final class CampaignPushConstants {
         static final String REMIND_TS = "remindTimestamp";
         static final String REMIND_LABEL = "remindLaterLabel";
         static final String ACTION_BUTTONS_STRING = "actionButtonsString";
+        static final String AUTO_CANCEL = "autoCancel";
+        static final String TAG = "tag";
+        static final String TICKER = "ticker";
 
         private IntentKeys() {}
     }
@@ -133,6 +136,9 @@ final class CampaignPushConstants {
         public static final String CHANNEL_ID = "adb_channel_id";
         public static final String ICON = "adb_icon";
         public static final String IMAGE_URL = "adb_image";
+        public static final String TAG = "adb_tag";
+        public static final String TICKER = "adb_ticker";
+        public static final String STICKY = "adb_sticky";
         public static final String ACTION_TYPE = "adb_a_type";
         public static final String ACTION_URI = "adb_uri";
         public static final String ACTION_BUTTONS = "adb_act";

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
@@ -129,6 +129,7 @@ final class CampaignPushConstants {
         public static final String TEMPLATE_TYPE = "adb_template_type";
         public static final String TITLE = "adb_title";
         public static final String BODY = "adb_body";
+        public static final String ACC_PAYLOAD_BODY = "_msg";
         public static final String SOUND = "adb_sound";
         public static final String BADGE_NUMBER = "adb_n_count";
         public static final String NOTIFICATION_VISIBILITY = "adb_n_visibility";

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -24,7 +24,7 @@ import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CampaignPushTrackerActivity extends Activity {
+class CampaignPushTrackerActivity extends Activity {
 
     private static final String SELF_TAG = "CampaignPushTrackerActivity";
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushUtils.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushUtils.java
@@ -91,6 +91,7 @@ class CampaignPushUtils {
                         "Failed to download push notification image from url (%s). Exception: %s",
                         url,
                         e.getMessage());
+                return null;
             } finally {
                 if (inputStream != null) {
                     try {
@@ -245,9 +246,9 @@ class CampaignPushUtils {
 
     /**
      * Downloads an image using the provided uri {@code String}. Prior to downloading, the image uri
-     * is used o retrieve a {@code CacheResult} containing a previously cached image. If no cache
-     * result is returned then a call to {@link CampaignPushUtils#download(String)} is made to
-     * download then cache the image.
+     * is used to retrieve a {@code CacheResult} containing a previously cached image. If no cache
+     * result is returned, a call to {@link CampaignPushUtils#download(String)} is made to download
+     * then cache the image.
      *
      * <p>If a valid cache result is returned then no image is downloaded. Instead, a {@code Bitmap}
      * is created from the cache result and returned by this method.

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CarouselTemplateNotificationBuilder.java
@@ -39,10 +39,6 @@ class CarouselTemplateNotificationBuilder {
 
         if (carouselOperationMode.equals(
                 CampaignPushConstants.DefaultValues.MANUAL_CAROUSEL_MODE)) {
-            Log.trace(
-                    CampaignPushConstants.LOG_TAG,
-                    SELF_TAG,
-                    "Building a manual carousel push notification.");
             return buildManualCarouselNotification(pushTemplate, context, channelId, packageName);
         }
 
@@ -64,9 +60,17 @@ class CarouselTemplateNotificationBuilder {
         final String carouselLayoutType = pushTemplate.getCarouselLayoutType();
         if (carouselLayoutType.equals(
                 CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_MODE)) {
+            Log.trace(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Building a manual filmstrip carousel push notification.");
             return FilmstripCarouselTemplateNotificationBuilder.construct(
                     pushTemplate, context, channelId, packageName);
         }
+        Log.trace(
+                CampaignPushConstants.LOG_TAG,
+                SELF_TAG,
+                "Building a default manual carousel push notification.");
         return ManualCarouselTemplateNotificationBuilder.construct(
                 pushTemplate, context, channelId, packageName);
     }

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -84,6 +84,8 @@ class FilmstripCarouselTemplateNotificationBuilder {
         }
     }
 
+    // TODO: migrate logic of building the notification to a common class to be used by
+    // FilmstripCarouselTemplateNotificationBuilder and ManualCarouselTemplateNotificationBuilder
     private static NotificationCompat.Builder createNotificationBuilder(
             final Context context,
             final CarouselPushTemplate pushTemplate,

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
@@ -33,11 +33,13 @@ class LegacyNotificationBuilder {
                         pushTemplate.getNotificationImportance());
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(context, channelId)
+                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
+                        .setTicker(pushTemplate.getNotificationTicker())
                         .setContentTitle(pushTemplate.getTitle())
                         .setContentText(pushTemplate.getBody())
                         .setNumber(pushTemplate.getBadgeCount())
                         .setPriority(pushTemplate.getNotificationPriority())
-                        .setAutoCancel(true);
+                        .setAutoCancel(pushTemplate.getNotificationAutoCancel());
 
         AEPPushNotificationBuilder.setLargeIcon(
                 builder,
@@ -61,7 +63,7 @@ class LegacyNotificationBuilder {
                 pushTemplate.getActionButtonsString(),
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId()); // Add action buttons if any
-        AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound(), false);
+        AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound());
         AEPPushNotificationBuilder.setNotificationClickAction(
                 context,
                 builder,

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -45,23 +45,69 @@ class ManualCarouselTemplateNotificationBuilder {
             final String channelId,
             final String packageName)
             throws NotificationConstructionFailedException {
-        final RemoteViews smallLayout =
-                new RemoteViews(packageName, R.layout.push_template_collapsed);
-        final RemoteViews expandedLayout =
-                new RemoteViews(packageName, R.layout.push_template_manual_carousel);
-        final CacheService cacheService = ServiceProvider.getInstance().getCacheService();
-
-        if (cacheService == null) {
-            throw new NotificationConstructionFailedException(
-                    "Cache service is null, manual carousel notification will not be"
-                            + " constructed.");
-        }
 
         if (pushTemplate == null) {
             throw new NotificationConstructionFailedException(
                     "Invalid push template received, manual carousel notification will not be"
                             + " constructed.");
         }
+
+        return createNotificationBuilder(context, pushTemplate, packageName, channelId);
+    }
+
+    static void handleIntent(final Context context, final Intent intent) {
+        // get manual carousel notification values from the intent extras
+        final Bundle intentExtras = intent.getExtras();
+        if (intentExtras == null) {
+            Log.trace(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Intent extras are null, will not create a notification from the received"
+                            + " intent with action %s",
+                    intent.getAction());
+            return;
+        }
+
+        try {
+            final NotificationManagerCompat notificationManager =
+                    NotificationManagerCompat.from(context);
+            final Notification notification = createNotificationBuilder(context, intent).build();
+
+            // get the tag from the intent extras. if no tag was present in the payload use the
+            // message id instead as its guaranteed to always be present.
+            final String tag =
+                    !StringUtils.isNullOrEmpty(
+                                    intentExtras.getString(CampaignPushConstants.IntentKeys.TAG))
+                            ? intentExtras.getString(CampaignPushConstants.IntentKeys.TAG)
+                            : intentExtras.getString(CampaignPushConstants.IntentKeys.MESSAGE_ID);
+            notificationManager.notify(tag.hashCode(), notification);
+        } catch (final NotificationConstructionFailedException exception) {
+            Log.error(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Failed to create a push notification, a notification construction failed"
+                            + " exception occurred: %s",
+                    exception.getLocalizedMessage());
+        }
+    }
+
+    private static NotificationCompat.Builder createNotificationBuilder(
+            final Context context,
+            final CarouselPushTemplate pushTemplate,
+            final String packageName,
+            final String channelId)
+            throws NotificationConstructionFailedException {
+        final CacheService cacheService = ServiceProvider.getInstance().getCacheService();
+        if (cacheService == null) {
+            throw new NotificationConstructionFailedException(
+                    "Cache service is null, default manual carousel push notification will not be"
+                            + " constructed.");
+        }
+
+        final RemoteViews smallLayout =
+                new RemoteViews(packageName, R.layout.push_template_collapsed);
+        final RemoteViews expandedLayout =
+                new RemoteViews(packageName, R.layout.push_template_manual_carousel);
 
         // load images into the carousel
         final ArrayList<CarouselPushTemplate.CarouselItem> items = pushTemplate.getCarouselItems();
@@ -100,57 +146,158 @@ class ManualCarouselTemplateNotificationBuilder {
 
         final int centerImageIndex =
                 CampaignPushConstants.DefaultValues.CENTER_INDEX; // center index defaults to 1
-        return createNotificationBuilder(
+
+        // assign a click action pending intent to the currently displayed carousel item
+        AEPPushNotificationBuilder.setRemoteViewClickAction(
                 context,
                 expandedLayout,
-                smallLayout,
-                centerImageIndex,
-                pushTemplate.getBadgeCount(),
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                        ? pushTemplate.getNotificationVisibility()
-                        : pushTemplate.getNotificationPriority(),
-                pushTemplate.getNotificationImportance(),
-                true,
-                channelId,
-                pushTemplate.getSound(),
-                titleText,
-                smallBodyText,
-                expandedBodyText,
+                R.id.carousel_item_image_view,
+                pushTemplate.getMessageId(),
+                pushTemplate.getDeliveryId(),
+                imageClickActions.get(centerImageIndex));
+
+        // set any custom colors if needed
+        AEPPushNotificationBuilder.setCustomNotificationColors(
                 pushTemplate.getNotificationBackgroundColor(),
                 pushTemplate.getTitleTextColor(),
                 pushTemplate.getExpandedBodyTextColor(),
-                pushTemplate.getMessageId(),
-                pushTemplate.getDeliveryId(),
-                pushTemplate.getIcon(),
-                pushTemplate.getSmallIconColor(),
-                downloadedImageUris,
-                imageCaptions,
-                imageClickActions);
+                smallLayout,
+                expandedLayout,
+                R.id.carousel_container_layout);
+
+        // handle left and right navigation buttons
+        final Intent clickIntent =
+                new Intent(
+                        CampaignPushConstants.IntentActions.MANUAL_CAROUSEL_LEFT_CLICKED,
+                        null,
+                        context,
+                        AEPPushTemplateBroadcastReceiver.class);
+        clickIntent.setClass(context, AEPPushTemplateBroadcastReceiver.class);
+        clickIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.CHANNEL_ID, channelId);
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.CUSTOM_SOUND, pushTemplate.getSound());
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.CENTER_IMAGE_INDEX, centerImageIndex);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMAGE_URLS, downloadedImageUris);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMAGE_CAPTIONS, imageCaptions);
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.IMAGE_CLICK_ACTIONS, imageClickActions);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.TITLE_TEXT, titleText);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.BODY_TEXT, pushTemplate.getBody());
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.EXPANDED_BODY_TEXT, expandedBodyText);
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.NOTIFICATION_BACKGROUND_COLOR,
+                pushTemplate.getNotificationBackgroundColor());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.TITLE_TEXT_COLOR,
+                pushTemplate.getTitleTextColor());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.EXPANDED_BODY_TEXT_COLOR,
+                pushTemplate.getExpandedBodyTextColor());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.MESSAGE_ID, pushTemplate.getMessageId());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.DELIVERY_ID, pushTemplate.getDeliveryId());
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.SMALL_ICON, pushTemplate.getIcon());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.SMALL_ICON_COLOR,
+                pushTemplate.getSmallIconColor());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.VISIBILITY,
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        ? pushTemplate.getNotificationVisibility()
+                        : pushTemplate.getNotificationPriority());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.IMPORTANCE,
+                pushTemplate.getNotificationImportance());
+
+        final PendingIntent pendingIntentLeftButton =
+                PendingIntent.getBroadcast(
+                        context,
+                        0,
+                        clickIntent,
+                        PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+        clickIntent.setAction(CampaignPushConstants.IntentActions.MANUAL_CAROUSEL_RIGHT_CLICKED);
+        final PendingIntent pendingIntentRightButton =
+                PendingIntent.getBroadcast(
+                        context,
+                        0,
+                        clickIntent,
+                        PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
+
+        expandedLayout.setOnClickPendingIntent(R.id.leftImageButton, pendingIntentLeftButton);
+        expandedLayout.setOnClickPendingIntent(R.id.rightImageButton, pendingIntentRightButton);
+
+        final NotificationCompat.Builder builder =
+                new NotificationCompat.Builder(context, channelId)
+                        .setNumber(pushTemplate.getBadgeCount())
+                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
+                        .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
+                        .setCustomContentView(smallLayout)
+                        .setCustomBigContentView(expandedLayout);
+
+        // set custom sound, note this applies to API 25 and lower only as API 26 and up set the
+        // sound on the notification channel
+        AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound());
+
+        // small Icon must be present, otherwise the notification will not be displayed.
+        AEPPushNotificationBuilder.setSmallIcon(
+                context, builder, pushTemplate.getIcon(), pushTemplate.getSmallIconColor());
+
+        // set notification visibility
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            AEPPushNotificationBuilder.setVisibility(
+                    builder, pushTemplate.getNotificationVisibility());
+        }
+
+        // if API level is below 26 (prior to notification channels) then notification priority is
+        // set on the notification builder
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.O) {
+            builder.setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setVibrate(
+                            new long[0]); // hack to enable heads up notifications as a HUD style
+            // notification requires a tone or vibration
+        }
+
+        return builder;
     }
 
-    static void handleIntent(final Context context, final Intent intent) {
-        final NotificationManagerCompat notificationManager =
-                NotificationManagerCompat.from(context);
+    private static NotificationCompat.Builder createNotificationBuilder(
+            final Context context, final Intent intent)
+            throws NotificationConstructionFailedException {
+        final Bundle intentExtras = intent.getExtras();
+        if (intentExtras == null) {
+            throw new NotificationConstructionFailedException(
+                    "Intent extras are null, will not create a notification from the received"
+                            + " intent with action "
+                            + intent.getAction());
+        }
+
+        final CacheService cacheService = ServiceProvider.getInstance().getCacheService();
+        if (cacheService == null) {
+            throw new NotificationConstructionFailedException(
+                    "Cache service is null, default manual carousel notification will not be"
+                            + " constructed.");
+        }
+
+        final String assetCacheLocation = CampaignPushUtils.getAssetCacheLocation();
         final String packageName =
                 ServiceProvider.getInstance()
                         .getAppContextService()
                         .getApplication()
                         .getPackageName();
 
-        // get carousel notification values from the intent extras
-        final Bundle intentExtras = intent.getExtras();
-        if (intentExtras == null) {
-            Log.trace(
-                    CampaignPushConstants.LOG_TAG,
-                    SELF_TAG,
-                    "Intent extras are null, will not create a notification from the received"
-                            + " intent with action %s",
-                    intent.getAction());
-            return;
-        }
-
-        final CacheService cacheService = ServiceProvider.getInstance().getCacheService();
-        final String assetCacheLocation = CampaignPushUtils.getAssetCacheLocation();
+        // get manual carousel notification values from the intent extras
+        final String messageId =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.MESSAGE_ID);
+        final String deliveryId =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.DELIVERY_ID);
+        final String channelId =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.CHANNEL_ID);
+        final int badgeCount = intentExtras.getInt(CampaignPushConstants.IntentKeys.BADGE_COUNT);
+        final int visibility = intentExtras.getInt(CampaignPushConstants.IntentKeys.VISIBILITY);
+        final int importance = intentExtras.getInt(CampaignPushConstants.IntentKeys.IMPORTANCE);
         final ArrayList<Bitmap> cachedImages = new ArrayList<>();
         final ArrayList<String> imageUrls =
                 (ArrayList<String>) intentExtras.get(CampaignPushConstants.IntentKeys.IMAGE_URLS);
@@ -165,7 +312,24 @@ class ManualCarouselTemplateNotificationBuilder {
         final String bodyText = intentExtras.getString(CampaignPushConstants.IntentKeys.BODY_TEXT);
         final String expandedBodyText =
                 intentExtras.getString(CampaignPushConstants.IntentKeys.EXPANDED_BODY_TEXT);
+        final String notificationBackgroundColor =
+                intentExtras.getString(
+                        CampaignPushConstants.IntentKeys.NOTIFICATION_BACKGROUND_COLOR);
+        final String titleTextColor =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.TITLE_TEXT_COLOR);
+        final String expandedBodyTextColor =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.EXPANDED_BODY_TEXT_COLOR);
+        final String smallIcon =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.SMALL_ICON);
+        final String smallIconColor =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.SMALL_ICON_COLOR);
+        final String customSound =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
+        final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
+        final boolean autoCancel =
+                intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
 
+        // as we are handling an intent, the image URLS should already be cached
         if (cacheService != null && !CollectionUtils.isEmpty(imageUrls)) {
             for (final String imageUri : imageUrls) {
                 if (!StringUtils.isNullOrEmpty(imageUri)) {
@@ -189,7 +353,6 @@ class ManualCarouselTemplateNotificationBuilder {
         final String action = intent.getAction();
         int centerImageIndex =
                 intentExtras.getInt(CampaignPushConstants.IntentKeys.CENTER_IMAGE_INDEX);
-
         final List<Integer> newIndices =
                 CampaignPushUtils.calculateNewIndices(centerImageIndex, imageUrls.size(), action);
 
@@ -205,6 +368,7 @@ class ManualCarouselTemplateNotificationBuilder {
             newCenterIndex = newIndices.get(1);
         }
 
+        // update the carousel view flipper with the new center index
         final ArrayList<CarouselPushTemplate.CarouselItem> items = new ArrayList<>();
         final CarouselPushTemplate.CarouselItem centerCarouselItem =
                 new CarouselPushTemplate.CarouselItem(
@@ -212,95 +376,8 @@ class ManualCarouselTemplateNotificationBuilder {
                         imageCaptions.get(newCenterIndex),
                         imageClickActions.get(newCenterIndex));
         items.add(centerCarouselItem);
-
-        final String messageId =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.MESSAGE_ID);
-        final String deliveryId =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.DELIVERY_ID);
-        final int badgeCount = intentExtras.getInt(CampaignPushConstants.IntentKeys.BADGE_COUNT);
-        final int visibility = intentExtras.getInt(CampaignPushConstants.IntentKeys.VISIBILITY);
-        final int importance = intentExtras.getInt(CampaignPushConstants.IntentKeys.IMPORTANCE);
-        final String channelId =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.CHANNEL_ID);
-        final String notificationBackgroundColor =
-                intentExtras.getString(
-                        CampaignPushConstants.IntentKeys.NOTIFICATION_BACKGROUND_COLOR);
-        final String titleTextColor =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.TITLE_TEXT_COLOR);
-        final String expandedBodyTextColor =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.EXPANDED_BODY_TEXT_COLOR);
-        final String smallIcon =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.SMALL_ICON);
-        final String smallIconColor =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.SMALL_ICON_COLOR);
-        final String customSound =
-                intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
-
         populateImages(
                 context, cacheService, expandedLayout, items, packageName, messageId, deliveryId);
-
-        final Notification notification =
-                createNotificationBuilder(
-                                context,
-                                expandedLayout,
-                                smallLayout,
-                                newCenterIndex,
-                                badgeCount,
-                                visibility,
-                                importance,
-                                true,
-                                channelId,
-                                customSound,
-                                titleText,
-                                bodyText,
-                                expandedBodyText,
-                                notificationBackgroundColor,
-                                titleTextColor,
-                                expandedBodyTextColor,
-                                messageId,
-                                deliveryId,
-                                smallIcon,
-                                smallIconColor,
-                                imageUrls,
-                                imageCaptions,
-                                imageClickActions)
-                        .build();
-
-        notificationManager.notify(messageId.hashCode(), notification);
-    }
-
-    private static NotificationCompat.Builder createNotificationBuilder(
-            final Context context,
-            final RemoteViews expandedLayout,
-            final RemoteViews smallLayout,
-            final int centerImageIndex,
-            final int badgeCount,
-            final int visibility,
-            final int importance,
-            final boolean handlingIntent,
-            final String channelId,
-            final String customSound,
-            final String titleText,
-            final String bodyText,
-            final String expandedBodyText,
-            final String notificationBackgroundColor,
-            final String titleTextColor,
-            final String expandedBodyTextColor,
-            final String messageId,
-            final String deliveryId,
-            final String smallIcon,
-            final String smallIconColor,
-            final ArrayList<String> downloadedImageUris,
-            final ArrayList<String> imageCaptions,
-            final ArrayList<String> imageClickActions) {
-
-        AEPPushNotificationBuilder.setRemoteViewClickAction(
-                context,
-                expandedLayout,
-                R.id.carousel_item_image_view,
-                messageId,
-                deliveryId,
-                imageClickActions.get(centerImageIndex));
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -322,8 +399,8 @@ class ManualCarouselTemplateNotificationBuilder {
         clickIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.CHANNEL_ID, channelId);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.CUSTOM_SOUND, customSound);
-        clickIntent.putExtra(CampaignPushConstants.IntentKeys.CENTER_IMAGE_INDEX, centerImageIndex);
-        clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMAGE_URLS, downloadedImageUris);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.CENTER_IMAGE_INDEX, newCenterIndex);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMAGE_URLS, imageUrls);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMAGE_CAPTIONS, imageCaptions);
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.IMAGE_CLICK_ACTIONS, imageClickActions);
@@ -358,43 +435,42 @@ class ManualCarouselTemplateNotificationBuilder {
                         clickIntent,
                         PendingIntent.FLAG_MUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
 
+        // set onclick intents for the skip left and skip right buttons
         expandedLayout.setOnClickPendingIntent(R.id.leftImageButton, pendingIntentLeftButton);
         expandedLayout.setOnClickPendingIntent(R.id.rightImageButton, pendingIntentRightButton);
 
-        NotificationCompat.Builder builder;
+        // we need to create a silent notification as this will be re-displaying a notification
+        // rather than showing a new one.
+        // the silent sound is set on the notification channel and notification builder.
+        Log.trace(
+                CampaignPushConstants.LOG_TAG,
+                SELF_TAG,
+                "Displaying a silent notification after handling an intent.");
 
-        if (handlingIntent) {
-            // we need to create a silent notification as this will be re-displaying a notification
-            // rather than showing a new one.
-            // the silent sound is set on the notification channel and notification builder.
-            Log.trace(CampaignPushConstants.LOG_TAG, SELF_TAG, "Building a silent notification.");
-            builder =
-                    new NotificationCompat.Builder(
-                            context,
-                            CampaignPushConstants.DefaultValues.SILENT_NOTIFICATION_CHANNEL_ID);
+        // Create the notification
+        final NotificationCompat.Builder builder =
+                new NotificationCompat.Builder(
+                                context,
+                                CampaignPushConstants.DefaultValues.SILENT_NOTIFICATION_CHANNEL_ID)
+                        .setSound(null)
+                        .setTicker(ticker)
+                        .setNumber(badgeCount)
+                        .setAutoCancel(autoCancel)
+                        .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
+                        .setCustomContentView(smallLayout)
+                        .setCustomBigContentView(expandedLayout);
 
-            AEPPushNotificationBuilder.setSound(context, builder, customSound, true);
-        } else {
-            builder = new NotificationCompat.Builder(context, channelId);
-            AEPPushNotificationBuilder.setSound(context, builder, customSound, false);
-        }
+        // small Icon must be present, otherwise the notification will not be displayed.
+        AEPPushNotificationBuilder.setSmallIcon(context, builder, smallIcon, smallIconColor);
 
-        builder.setNumber(badgeCount)
-                .setAutoCancel(true)
-                .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
-                .setCustomContentView(smallLayout)
-                .setCustomBigContentView(expandedLayout);
-
-        AEPPushNotificationBuilder.setSmallIcon(
-                context,
-                builder,
-                smallIcon,
-                smallIconColor); // Small Icon must be present, otherwise the notification will not
-        // be displayed.
-
+        // set notification visibility
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             AEPPushNotificationBuilder.setVisibility(builder, visibility);
         }
+
+        // set notification delete action
+        AEPPushNotificationBuilder.setNotificationDeleteAction(
+                context, builder, messageId, deliveryId);
 
         // if API level is below 26 (prior to notification channels) then notification priority is
         // set on the notification builder

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -91,6 +91,8 @@ class ManualCarouselTemplateNotificationBuilder {
         }
     }
 
+    // TODO: migrate logic of building the notification to a common class to be used by
+    // FilmstripCarouselTemplateNotificationBuilder and ManualCarouselTemplateNotificationBuilder
     private static NotificationCompat.Builder createNotificationBuilder(
             final Context context,
             final CarouselPushTemplate pushTemplate,

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     package="com.adobe.campaignclassictestapp">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:allowBackup="true"

--- a/code/testapp/src/main/java/com/adobe/campaignclassictestapp/NotificationService.java
+++ b/code/testapp/src/main/java/com/adobe/campaignclassictestapp/NotificationService.java
@@ -50,28 +50,6 @@ public class NotificationService extends FirebaseMessagingService {
 		} else {
 			// Handle notification from other sources
 		}
-
-//		displayNotification(remoteMessage);
-//
-//		// Check if message contains a data payload.
-//		if (remoteMessage.getData().size() > 0) {
-//			Log.d(LOG_TAG, "Message data payload: " + remoteMessage.getData());
-//		}
-//
-//		// Check if message contains a notification payload.
-//		if (remoteMessage.getNotification() != null) {
-//			Log.d(LOG_TAG, "Message Notification Body: " + remoteMessage.getNotification().getBody());
-//			Log.d(LOG_TAG, "Message Notification channel id: " + remoteMessage.getNotification().getChannelId());
-//			Log.d(LOG_TAG, "Message Notification icon: " + remoteMessage.getNotification().getIcon());
-//			Log.d(LOG_TAG, "Message Notification sound: " + remoteMessage.getNotification().getSound());
-//			Log.d(LOG_TAG, "Message Notification color: " + remoteMessage.getNotification().getColor());
-//			Log.d(LOG_TAG, "Message Notification tag: " + remoteMessage.getNotification().getTag());
-//			Log.d(LOG_TAG, "Message Notification image: " + remoteMessage.getNotification().getImageUrl());
-//			Log.d(LOG_TAG, "Message Notification count: " + remoteMessage.getNotification().getNotificationCount());
-//			Log.d(LOG_TAG, "Message Notification sticky: " + remoteMessage.getNotification().getSticky());
-//			Log.d(LOG_TAG, "Message Notification priority: " + remoteMessage.getNotification().getNotificationPriority());
-//			Log.d(LOG_TAG, "Message Notification visibility: " + remoteMessage.getNotification().getVisibility());
-//		}
 	}
 
 	private void displayNotification(RemoteMessage remoteMessage) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
in addition:
- use the three new KVP's imported from the ACC push payloads when building a notification (tag, ticker, and sticky / autocancel)
- refactor createNotificationBuilder functions to accept either a AEPPushTemplate or Intent object to shorten the parameter lists.
- clean up setSound function within AEPPushNotificationBuilder
- minor bug fix: return null if an IOException occurs when downloading an image to prevent a false download success message from displaying.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
