### PR TITLE
MOB-20232: fix for manual carousel skip buttons, fix silent notification channel creation

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.0";
+    static final String EXTENSION_VERSION = "2.1.1";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -118,6 +118,9 @@ class AEPPushNotificationBuilder {
                     (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             final String channelIdFromPayload = channelId;
 
+            // setup a silent channel for notification carousel item change
+            setupSilentNotificationChannel(context, notificationManager, importance);
+
             // if a channel from the payload is not null and if a channel exists for the channel ID
             // from the payload, use the same channel ID.
             if (channelIdFromPayload != null
@@ -147,9 +150,6 @@ class AEPPushNotificationBuilder {
 
                 // add the channel to the notification manager
                 notificationManager.createNotificationChannel(channel);
-
-                // setup a silent channel for notification carousel item change
-                setupSilentNotificationChannel(context, notificationManager, importance);
 
                 return channelIdFromPayload;
             } else {
@@ -188,6 +188,16 @@ class AEPPushNotificationBuilder {
             final NotificationManager notificationManager,
             final int importance) {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O) {
+            return;
+        }
+
+        if (notificationManager.getNotificationChannel(
+                        CampaignPushConstants.DefaultValues.SILENT_NOTIFICATION_CHANNEL_ID)
+                != null) {
+            Log.trace(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Using previously created silent channel.");
             return;
         }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -235,10 +235,12 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.IMPORTANCE,
                 pushTemplate.getNotificationImportance());
         clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.TICKER, pushTemplate.getNotificationTicker());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
+        clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.AUTO_CANCEL,
                 pushTemplate.getNotificationAutoCancel());
-        clickIntent.putExtra(
-                CampaignPushConstants.IntentKeys.TICKER, pushTemplate.getNotificationTicker());
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -362,6 +364,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
         final String customSound =
                 intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
+        final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
         final boolean autoCancel =
                 intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
 
@@ -474,6 +477,9 @@ class FilmstripCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.SMALL_ICON_COLOR, smallIconColor);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.VISIBILITY, visibility);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMPORTANCE, importance);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.TICKER, ticker);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.TAG, tag);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.AUTO_CANCEL, autoCancel);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -209,6 +209,13 @@ class ManualCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.IMPORTANCE,
                 pushTemplate.getNotificationImportance());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.AUTO_CANCEL,
+                pushTemplate.getNotificationAutoCancel());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
+        clickIntent.putExtra(
+                CampaignPushConstants.IntentKeys.TICKER, pushTemplate.getNotificationTicker());
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -230,6 +237,7 @@ class ManualCarouselTemplateNotificationBuilder {
 
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(context, channelId)
+                        .setTicker(pushTemplate.getNotificationTicker())
                         .setNumber(pushTemplate.getBadgeCount())
                         .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
@@ -325,6 +333,7 @@ class ManualCarouselTemplateNotificationBuilder {
         final String customSound =
                 intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
+        final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
         final boolean autoCancel =
                 intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
 
@@ -418,6 +427,9 @@ class ManualCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.SMALL_ICON_COLOR, smallIconColor);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.VISIBILITY, visibility);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMPORTANCE, importance);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.TICKER, ticker);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.TAG, tag);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.AUTO_CANCEL, autoCancel);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -23,7 +23,7 @@ public class CampaignClassic {
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
 
-    static final String EXTENSION_VERSION = "2.1.0";
+    static final String EXTENSION_VERSION = "2.1.1";
     static final String REGISTER_DEVICE = "registerdevice";
     static final String TRACK_RECEIVE = "trackreceive";
     static final String TRACK_CLICK = "trackclick";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.0";
+    static final String EXTENSION_VERSION = "2.1.1";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.configureondemand=false
 
 moduleProjectName=campaignclassic
 moduleName=campaignclassic
-moduleVersion=2.1.0
+moduleVersion=2.1.1
 moduleAARName=campaignclassic-phone-release.aar
 
 #Maven artifact


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- the tag was not being added to the skip button intents which was causing duplicate notifications to be displayed.
- fix silent notification channel creation. ensure it is always created when notification channels are setup.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
