### PR TITLE
fix notification sticky behavior, bump version to 2.1.2

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.1";
+    static final String EXTENSION_VERSION = "2.1.2";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -399,7 +399,7 @@ class AEPPushNotificationBuilder {
     }
 
     /**
-     * Sets the click action for the notification buttons.
+     * Sets the click action for the notification.
      *
      * @param context the application {@link Context}
      * @param notificationBuilder the notification builder
@@ -407,15 +407,21 @@ class AEPPushNotificationBuilder {
      * @param deliveryId {@code String} containing the delivery id from the received push
      *     notification
      * @param actionUri the action uri
+     * @param tag the tag used when scheduling the notification
+     * @param stickyNotification {@code boolean} if false, remove the notification after the {@code
+     *     RemoteViews} is pressed
      */
     static void setNotificationClickAction(
             final Context context,
             final NotificationCompat.Builder notificationBuilder,
             final String messageId,
             final String deliveryId,
-            final String actionUri) {
+            final String actionUri,
+            final String tag,
+            final boolean stickyNotification) {
         final PendingIntent pendingIntent =
-                createPendingIntent(context, messageId, deliveryId, actionUri, null);
+                createPendingIntent(
+                        context, messageId, deliveryId, actionUri, null, tag, stickyNotification);
         notificationBuilder.setContentIntent(pendingIntent);
     }
 
@@ -431,6 +437,9 @@ class AEPPushNotificationBuilder {
      * @param deliveryId {@code String} containing the delivery id from the received push
      *     notification
      * @param actionUri {@code String} containing the action uri defined for the push template image
+     * @param tag the tag used when scheduling the notification
+     * @param stickyNotification {@code boolean} if false, remove the notification after the {@code
+     *     RemoteViews} is pressed
      */
     static void setRemoteViewClickAction(
             final Context context,
@@ -438,9 +447,12 @@ class AEPPushNotificationBuilder {
             final int targetViewResourceId,
             final String messageId,
             final String deliveryId,
-            final String actionUri) {
+            final String actionUri,
+            final String tag,
+            final boolean stickyNotification) {
         final PendingIntent pendingIntent =
-                createPendingIntent(context, messageId, deliveryId, actionUri, null);
+                createPendingIntent(
+                        context, messageId, deliveryId, actionUri, null, tag, stickyNotification);
         pushTemplateRemoteView.setOnClickPendingIntent(targetViewResourceId, pendingIntent);
     }
 
@@ -478,13 +490,18 @@ class AEPPushNotificationBuilder {
      * @param messageId {@code String} containing the message id from the received push notification
      * @param deliveryId {@code String} containing the delivery id from the received push
      *     notification
+     * @param tag the tag used when scheduling the notification
+     * @param stickyNotification {@code boolean} if false, remove the notification after the action
+     *     button is pressed
      */
     static void addActionButtons(
             final Context context,
             final NotificationCompat.Builder builder,
             final String actionButtonsString,
             final String messageId,
-            final String deliveryId) {
+            final String deliveryId,
+            final String tag,
+            final boolean stickyNotification) {
         final List<AEPPushTemplate.ActionButton> actionButtons =
                 AEPPushTemplate.getActionButtonsFromString(actionButtonsString);
         if (actionButtons == null || actionButtons.isEmpty()) {
@@ -502,11 +519,19 @@ class AEPPushNotificationBuilder {
                                 messageId,
                                 deliveryId,
                                 eachButton.getLink(),
-                                eachButton.getLabel());
+                                eachButton.getLabel(),
+                                tag,
+                                stickyNotification);
             } else {
                 pendingIntent =
                         createPendingIntent(
-                                context, messageId, deliveryId, null, eachButton.getLabel());
+                                context,
+                                messageId,
+                                deliveryId,
+                                null,
+                                eachButton.getLabel(),
+                                tag,
+                                stickyNotification);
             }
             builder.addAction(0, eachButton.getLabel(), pendingIntent);
         }
@@ -521,6 +546,8 @@ class AEPPushNotificationBuilder {
      *     notification
      * @param actionUri the action uri
      * @param actionID the action ID
+     * @param stickyNotification {@code boolean} if false, remove the notification after the {@code
+     *     RemoteViews} is pressed
      * @return the pending intent
      */
     private static PendingIntent createPendingIntent(
@@ -528,12 +555,16 @@ class AEPPushNotificationBuilder {
             final String messageId,
             final String deliveryId,
             final String actionUri,
-            final String actionID) {
+            final String actionID,
+            final String tag,
+            final boolean stickyNotification) {
         final Intent intent = new Intent(CampaignPushConstants.NotificationAction.BUTTON_CLICKED);
         intent.setClass(context.getApplicationContext(), CampaignPushTrackerActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.putExtra(CampaignPushConstants.Tracking.Keys.MESSAGE_ID, messageId);
         intent.putExtra(CampaignPushConstants.Tracking.Keys.DELIVERY_ID, deliveryId);
+        intent.putExtra(CampaignPushConstants.PushPayloadKeys.TAG, tag);
+        intent.putExtra(CampaignPushConstants.PushPayloadKeys.STICKY, stickyNotification);
         addActionDetailsToIntent(intent, actionUri, actionID);
 
         // adding tracking details

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
@@ -401,7 +401,7 @@ class AEPPushTemplate {
         return ticker;
     }
 
-    boolean getNotificationAutoCancel() {
+    boolean getNotificationStickySetting() {
         return sticky;
     }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplate.java
@@ -401,7 +401,7 @@ class AEPPushTemplate {
         return ticker;
     }
 
-    boolean getNotificationStickySetting() {
+    boolean isNotificationSticky() {
         return sticky;
     }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
@@ -147,7 +147,7 @@ class AutoCarouselTemplateNotificationBuilder {
                     pushTemplate.getDeliveryId(),
                     item.getInteractionUri(),
                     pushTemplate.getNotificationTag(),
-                    pushTemplate.getNotificationStickySetting());
+                    pushTemplate.isNotificationSticky());
 
             // add the carousel item to the view flipper
             expandedLayout.addView(R.id.auto_carousel_view_flipper, carouselItem);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
@@ -82,7 +82,6 @@ class AutoCarouselTemplateNotificationBuilder {
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(context, channelId)
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -146,7 +145,9 @@ class AutoCarouselTemplateNotificationBuilder {
                     R.id.carousel_item_image_view,
                     pushTemplate.getMessageId(),
                     pushTemplate.getDeliveryId(),
-                    item.getInteractionUri());
+                    item.getInteractionUri(),
+                    pushTemplate.getNotificationTag(),
+                    pushTemplate.getNotificationStickySetting());
 
             // add the carousel item to the view flipper
             expandedLayout.addView(R.id.auto_carousel_view_flipper, carouselItem);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/BasicTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/BasicTemplateNotificationBuilder.java
@@ -106,7 +106,6 @@ class BasicTemplateNotificationBuilder {
                 new NotificationCompat.Builder(context, channelIdToUse)
                         .setTicker(pushTemplate.getNotificationTicker())
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -127,7 +126,9 @@ class BasicTemplateNotificationBuilder {
                 builder,
                 pushTemplate.getActionButtonsString(),
                 pushTemplate.getMessageId(),
-                pushTemplate.getDeliveryId());
+                pushTemplate.getDeliveryId(),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting());
 
         // add a remind later button if we have a label and a timestamp
         if (!StringUtils.isNullOrEmpty(pushTemplate.getRemindLaterText())
@@ -146,7 +147,9 @@ class BasicTemplateNotificationBuilder {
                 builder,
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
-                pushTemplate.getActionUri());
+                pushTemplate.getActionUri(),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting());
         AEPPushNotificationBuilder.setNotificationDeleteAction(
                 context, builder, pushTemplate.getMessageId(), pushTemplate.getDeliveryId());
 
@@ -240,8 +243,8 @@ class BasicTemplateNotificationBuilder {
         final String actionButtonsString =
                 intentExtras.getString(CampaignPushConstants.IntentKeys.ACTION_BUTTONS_STRING);
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
-        final boolean autoCancel =
-                intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
+        final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
+        final boolean sticky = intentExtras.getBoolean(CampaignPushConstants.IntentKeys.STICKY);
 
         final String channelIdToUse =
                 AEPPushNotificationBuilder.createChannelAndGetChannelID(
@@ -261,7 +264,6 @@ class BasicTemplateNotificationBuilder {
                 new NotificationCompat.Builder(context, channelIdToUse)
                         .setTicker(ticker)
                         .setNumber(badgeCount)
-                        .setAutoCancel(autoCancel)
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -280,7 +282,9 @@ class BasicTemplateNotificationBuilder {
                 builder,
                 actionButtonsString,
                 messageId,
-                deliveryId); // Add action buttons if any
+                deliveryId,
+                tag,
+                sticky); // Add action buttons if any
 
         // add a remind later button if we have a label and a timestamp
         if (!StringUtils.isNullOrEmpty(remindLaterText) && remindLaterTimestamp > 0) {
@@ -294,7 +298,7 @@ class BasicTemplateNotificationBuilder {
         AEPPushNotificationBuilder.setSound(context, builder, customSound);
 
         AEPPushNotificationBuilder.setNotificationClickAction(
-                context, builder, messageId, deliveryId, actionUri);
+                context, builder, messageId, deliveryId, actionUri, tag, sticky);
         AEPPushNotificationBuilder.setNotificationDeleteAction(
                 context, builder, messageId, deliveryId);
 
@@ -471,8 +475,8 @@ class BasicTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.ACTION_BUTTONS_STRING,
                 pushTemplate.getActionButtonsString());
         remindIntent.putExtra(
-                CampaignPushConstants.IntentKeys.AUTO_CANCEL,
-                pushTemplate.getNotificationAutoCancel());
+                CampaignPushConstants.IntentKeys.STICKY,
+                pushTemplate.getNotificationStickySetting());
         remindIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         remindIntent.putExtra(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/BasicTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/BasicTemplateNotificationBuilder.java
@@ -128,7 +128,7 @@ class BasicTemplateNotificationBuilder {
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting());
+                pushTemplate.isNotificationSticky());
 
         // add a remind later button if we have a label and a timestamp
         if (!StringUtils.isNullOrEmpty(pushTemplate.getRemindLaterText())
@@ -149,7 +149,7 @@ class BasicTemplateNotificationBuilder {
                 pushTemplate.getDeliveryId(),
                 pushTemplate.getActionUri(),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting());
+                pushTemplate.isNotificationSticky());
         AEPPushNotificationBuilder.setNotificationDeleteAction(
                 context, builder, pushTemplate.getMessageId(), pushTemplate.getDeliveryId());
 
@@ -475,8 +475,7 @@ class BasicTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.ACTION_BUTTONS_STRING,
                 pushTemplate.getActionButtonsString());
         remindIntent.putExtra(
-                CampaignPushConstants.IntentKeys.STICKY,
-                pushTemplate.getNotificationStickySetting());
+                CampaignPushConstants.IntentKeys.STICKY, pushTemplate.isNotificationSticky());
         remindIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         remindIntent.putExtra(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
@@ -101,7 +101,7 @@ final class CampaignPushConstants {
         static final String REMIND_TS = "remindTimestamp";
         static final String REMIND_LABEL = "remindLaterLabel";
         static final String ACTION_BUTTONS_STRING = "actionButtonsString";
-        static final String AUTO_CANCEL = "autoCancel";
+        static final String STICKY = "sticky";
         static final String TAG = "tag";
         static final String TICKER = "ticker";
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -180,7 +180,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 pushTemplate.getDeliveryId(),
                 imageClickActions.get(centerImageIndex),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting());
+                pushTemplate.isNotificationSticky());
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -241,8 +241,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         clickIntent.putExtra(
-                CampaignPushConstants.IntentKeys.STICKY,
-                pushTemplate.getNotificationStickySetting());
+                CampaignPushConstants.IntentKeys.STICKY, pushTemplate.isNotificationSticky());
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -178,7 +178,9 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 R.id.manual_carousel_filmstrip_center,
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
-                imageClickActions.get(centerImageIndex));
+                imageClickActions.get(centerImageIndex),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting());
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -239,8 +241,8 @@ class FilmstripCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         clickIntent.putExtra(
-                CampaignPushConstants.IntentKeys.AUTO_CANCEL,
-                pushTemplate.getNotificationAutoCancel());
+                CampaignPushConstants.IntentKeys.STICKY,
+                pushTemplate.getNotificationStickySetting());
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -266,7 +268,6 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 new NotificationCompat.Builder(context, channelId)
                         .setTicker(pushTemplate.getNotificationTicker())
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -365,8 +366,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
         final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
-        final boolean autoCancel =
-                intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
+        final boolean sticky = intentExtras.getBoolean(CampaignPushConstants.IntentKeys.STICKY);
 
         // as we are handling an intent, the image URLS should already be cached
         if (cacheService != null && !CollectionUtils.isEmpty(imageUrls)) {
@@ -435,7 +435,9 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 R.id.manual_carousel_filmstrip_center,
                 messageId,
                 deliveryId,
-                imageClickActions.get(newCenterIndex));
+                imageClickActions.get(newCenterIndex),
+                tag,
+                sticky);
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -479,7 +481,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMPORTANCE, importance);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TICKER, ticker);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TAG, tag);
-        clickIntent.putExtra(CampaignPushConstants.IntentKeys.AUTO_CANCEL, autoCancel);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.STICKY, sticky);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -516,7 +518,6 @@ class FilmstripCarouselTemplateNotificationBuilder {
                         .setSound(null)
                         .setTicker(ticker)
                         .setNumber(badgeCount)
-                        .setAutoCancel(autoCancel)
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
@@ -33,13 +33,11 @@ class LegacyNotificationBuilder {
                         pushTemplate.getNotificationImportance());
         final NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(context, channelId)
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setTicker(pushTemplate.getNotificationTicker())
                         .setContentTitle(pushTemplate.getTitle())
                         .setContentText(pushTemplate.getBody())
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setPriority(pushTemplate.getNotificationPriority())
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel());
+                        .setPriority(pushTemplate.getNotificationPriority());
 
         AEPPushNotificationBuilder.setLargeIcon(
                 builder,
@@ -62,14 +60,18 @@ class LegacyNotificationBuilder {
                 builder,
                 pushTemplate.getActionButtonsString(),
                 pushTemplate.getMessageId(),
-                pushTemplate.getDeliveryId()); // Add action buttons if any
+                pushTemplate.getDeliveryId(),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting()); // Add action buttons if any
         AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound());
         AEPPushNotificationBuilder.setNotificationClickAction(
                 context,
                 builder,
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
-                pushTemplate.getActionUri());
+                pushTemplate.getActionUri(),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting());
         AEPPushNotificationBuilder.setNotificationDeleteAction(
                 context, builder, pushTemplate.getMessageId(), pushTemplate.getDeliveryId());
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/LegacyNotificationBuilder.java
@@ -62,7 +62,7 @@ class LegacyNotificationBuilder {
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting()); // Add action buttons if any
+                pushTemplate.isNotificationSticky()); // Add action buttons if any
         AEPPushNotificationBuilder.setSound(context, builder, pushTemplate.getSound());
         AEPPushNotificationBuilder.setNotificationClickAction(
                 context,
@@ -71,7 +71,7 @@ class LegacyNotificationBuilder {
                 pushTemplate.getDeliveryId(),
                 pushTemplate.getActionUri(),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting());
+                pushTemplate.isNotificationSticky());
         AEPPushNotificationBuilder.setNotificationDeleteAction(
                 context, builder, pushTemplate.getMessageId(), pushTemplate.getDeliveryId());
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -123,7 +123,7 @@ class ManualCarouselTemplateNotificationBuilder {
                         pushTemplate.getMessageId(),
                         pushTemplate.getDeliveryId(),
                         pushTemplate.getNotificationTag(),
-                        pushTemplate.getNotificationStickySetting());
+                        pushTemplate.isNotificationSticky());
 
         final ArrayList<String> downloadedImageUris = extractedItemData.get(IMAGE_URIS_KEY);
         final ArrayList<String> imageCaptions = extractedItemData.get(IMAGE_CAPTIONS_KEY);
@@ -157,7 +157,7 @@ class ManualCarouselTemplateNotificationBuilder {
                 pushTemplate.getDeliveryId(),
                 imageClickActions.get(centerImageIndex),
                 pushTemplate.getNotificationTag(),
-                pushTemplate.getNotificationStickySetting());
+                pushTemplate.isNotificationSticky());
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -214,8 +214,7 @@ class ManualCarouselTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.IMPORTANCE,
                 pushTemplate.getNotificationImportance());
         clickIntent.putExtra(
-                CampaignPushConstants.IntentKeys.STICKY,
-                pushTemplate.getNotificationStickySetting());
+                CampaignPushConstants.IntentKeys.STICKY, pushTemplate.isNotificationSticky());
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         clickIntent.putExtra(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -121,7 +121,9 @@ class ManualCarouselTemplateNotificationBuilder {
                         items,
                         packageName,
                         pushTemplate.getMessageId(),
-                        pushTemplate.getDeliveryId());
+                        pushTemplate.getDeliveryId(),
+                        pushTemplate.getNotificationTag(),
+                        pushTemplate.getNotificationStickySetting());
 
         final ArrayList<String> downloadedImageUris = extractedItemData.get(IMAGE_URIS_KEY);
         final ArrayList<String> imageCaptions = extractedItemData.get(IMAGE_CAPTIONS_KEY);
@@ -153,7 +155,9 @@ class ManualCarouselTemplateNotificationBuilder {
                 R.id.carousel_item_image_view,
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
-                imageClickActions.get(centerImageIndex));
+                imageClickActions.get(centerImageIndex),
+                pushTemplate.getNotificationTag(),
+                pushTemplate.getNotificationStickySetting());
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -210,8 +214,8 @@ class ManualCarouselTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.IMPORTANCE,
                 pushTemplate.getNotificationImportance());
         clickIntent.putExtra(
-                CampaignPushConstants.IntentKeys.AUTO_CANCEL,
-                pushTemplate.getNotificationAutoCancel());
+                CampaignPushConstants.IntentKeys.STICKY,
+                pushTemplate.getNotificationStickySetting());
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         clickIntent.putExtra(
@@ -239,7 +243,6 @@ class ManualCarouselTemplateNotificationBuilder {
                 new NotificationCompat.Builder(context, channelId)
                         .setTicker(pushTemplate.getNotificationTicker())
                         .setNumber(pushTemplate.getBadgeCount())
-                        .setAutoCancel(pushTemplate.getNotificationAutoCancel())
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -334,8 +337,7 @@ class ManualCarouselTemplateNotificationBuilder {
                 intentExtras.getString(CampaignPushConstants.IntentKeys.CUSTOM_SOUND);
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
         final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
-        final boolean autoCancel =
-                intentExtras.getBoolean(CampaignPushConstants.IntentKeys.AUTO_CANCEL);
+        final boolean sticky = intentExtras.getBoolean(CampaignPushConstants.IntentKeys.STICKY);
 
         // as we are handling an intent, the image URLS should already be cached
         if (cacheService != null && !CollectionUtils.isEmpty(imageUrls)) {
@@ -385,7 +387,15 @@ class ManualCarouselTemplateNotificationBuilder {
                         imageClickActions.get(newCenterIndex));
         items.add(centerCarouselItem);
         populateImages(
-                context, cacheService, expandedLayout, items, packageName, messageId, deliveryId);
+                context,
+                cacheService,
+                expandedLayout,
+                items,
+                packageName,
+                messageId,
+                deliveryId,
+                tag,
+                sticky);
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -429,7 +439,7 @@ class ManualCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.IMPORTANCE, importance);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TICKER, ticker);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TAG, tag);
-        clickIntent.putExtra(CampaignPushConstants.IntentKeys.AUTO_CANCEL, autoCancel);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.STICKY, sticky);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -466,7 +476,6 @@ class ManualCarouselTemplateNotificationBuilder {
                         .setSound(null)
                         .setTicker(ticker)
                         .setNumber(badgeCount)
-                        .setAutoCancel(autoCancel)
                         .setStyle(new NotificationCompat.DecoratedCustomViewStyle())
                         .setCustomContentView(smallLayout)
                         .setCustomBigContentView(expandedLayout);
@@ -502,7 +511,9 @@ class ManualCarouselTemplateNotificationBuilder {
             final ArrayList<CarouselPushTemplate.CarouselItem> items,
             final String packageName,
             final String messageId,
-            final String deliveryId) {
+            final String deliveryId,
+            final String tag,
+            final boolean autoCancel) {
         final ArrayList<String> downloadedImageUris = new ArrayList<>();
         final ArrayList<String> imageCaptions = new ArrayList<>();
         final ArrayList<String> imageClickActions = new ArrayList<>();
@@ -536,7 +547,9 @@ class ManualCarouselTemplateNotificationBuilder {
                     R.id.carousel_item_image_view,
                     messageId,
                     deliveryId,
-                    item.getInteractionUri());
+                    item.getInteractionUri(),
+                    tag,
+                    autoCancel);
 
             // add the carousel item to the view flipper
             expandedLayout.addView(R.id.manual_carousel_view_flipper, carouselItem);

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -23,7 +23,7 @@ public class CampaignClassic {
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
 
-    static final String EXTENSION_VERSION = "2.1.1";
+    static final String EXTENSION_VERSION = "2.1.2";
     static final String REGISTER_DEVICE = "registerdevice";
     static final String TRACK_RECEIVE = "trackreceive";
     static final String TRACK_CLICK = "trackclick";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.1";
+    static final String EXTENSION_VERSION = "2.1.2";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.configureondemand=false
 
 moduleProjectName=campaignclassic
 moduleName=campaignclassic
-moduleVersion=2.1.1
+moduleVersion=2.1.2
 moduleAARName=campaignclassic-phone-release.aar
 
 #Maven artifact


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The auto cancel setting being set on the `NotificationCompatBuilder` objects was not allowing the notifications to be dismissed after they were interacted with. To resolve this, `notificationManager.cancel()` is now called with the notification `tag.hashCode()` to remove a non-sticky notification after processing a push action.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
