### PR TITLE
Fix carousel item clicked behavior

### DIFF
--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushNotificationBuilder.java
@@ -275,7 +275,7 @@ class AEPPushNotificationBuilder {
             Log.trace(
                     CampaignPushConstants.LOG_TAG,
                     SELF_TAG,
-                    "Invalid large icon string provided, large icon will not be applied.");
+                    "Null or empty large icon string found, large icon will not be applied.");
             remoteView.setViewVisibility(R.id.large_icon, View.GONE);
             return;
         }
@@ -505,6 +505,22 @@ class AEPPushNotificationBuilder {
             final String actionUri,
             final String tag,
             final boolean stickyNotification) {
+        if (StringUtils.isNullOrEmpty(actionUri)) {
+            Log.trace(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "No valid action uri found for the clicked view with id %s. No click action"
+                            + " will be assigned.",
+                    targetViewResourceId);
+            return;
+        }
+
+        Log.trace(
+                CampaignPushConstants.LOG_TAG,
+                SELF_TAG,
+                "Setting remote view click action uri: %s ",
+                actionUri);
+
         final PendingIntent pendingIntent =
                 createPendingIntent(
                         context, messageId, deliveryId, actionUri, null, tag, stickyNotification);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AutoCarouselTemplateNotificationBuilder.java
@@ -19,6 +19,7 @@ import com.adobe.marketing.mobile.campaignclassic.R;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.services.caching.CacheService;
+import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -144,13 +145,17 @@ class AutoCarouselTemplateNotificationBuilder {
             carouselItem.setTextViewText(R.id.carousel_item_caption, item.getCaptionText());
 
             // assign a click action pending intent for each carousel item
+            final String interactionUri =
+                    !StringUtils.isNullOrEmpty(item.getInteractionUri())
+                            ? item.getInteractionUri()
+                            : pushTemplate.getActionUri();
             AEPPushNotificationBuilder.setRemoteViewClickAction(
                     context,
                     carouselItem,
                     R.id.carousel_item_image_view,
                     pushTemplate.getMessageId(),
                     pushTemplate.getDeliveryId(),
-                    item.getInteractionUri(),
+                    interactionUri,
                     pushTemplate.getNotificationTag(),
                     pushTemplate.isNotificationSticky());
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -172,13 +172,18 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 R.id.manual_carousel_filmstrip_right, downloadedImages.get(2));
 
         // assign a click action pending intent to the center image view
+        final String fallbackActionUri = pushTemplate.getActionUri();
+        final String interactionUri =
+                !StringUtils.isNullOrEmpty(imageClickActions.get(centerImageIndex))
+                        ? imageClickActions.get(centerImageIndex)
+                        : fallbackActionUri;
         AEPPushNotificationBuilder.setRemoteViewClickAction(
                 context,
                 expandedLayout,
                 R.id.manual_carousel_filmstrip_center,
                 pushTemplate.getMessageId(),
                 pushTemplate.getDeliveryId(),
-                imageClickActions.get(centerImageIndex),
+                interactionUri,
                 pushTemplate.getNotificationTag(),
                 pushTemplate.isNotificationSticky());
 
@@ -245,6 +250,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
                 CampaignPushConstants.IntentKeys.TAG, pushTemplate.getNotificationTag());
         clickIntent.putExtra(
                 CampaignPushConstants.IntentKeys.STICKY, pushTemplate.isNotificationSticky());
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.ACTION_URI, fallbackActionUri);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(
@@ -376,6 +382,8 @@ class FilmstripCarouselTemplateNotificationBuilder {
         final String ticker = intentExtras.getString(CampaignPushConstants.IntentKeys.TICKER);
         final String tag = intentExtras.getString(CampaignPushConstants.IntentKeys.TAG);
         final boolean sticky = intentExtras.getBoolean(CampaignPushConstants.IntentKeys.STICKY);
+        final String fallbackActionUri =
+                intentExtras.getString(CampaignPushConstants.IntentKeys.ACTION_URI);
 
         // as we are handling an intent, the image URLS should already be cached
         if (cacheService != null && !CollectionUtils.isEmpty(imageUrls)) {
@@ -438,13 +446,17 @@ class FilmstripCarouselTemplateNotificationBuilder {
         expandedLayout.setTextViewText(R.id.manual_carousel_filmstrip_caption, newCenterCaption);
 
         // assign a click action pending intent to the center image view
+        final String interactionUri =
+                !StringUtils.isNullOrEmpty(imageClickActions.get(newCenterIndex))
+                        ? imageClickActions.get(newCenterIndex)
+                        : fallbackActionUri;
         AEPPushNotificationBuilder.setRemoteViewClickAction(
                 context,
                 expandedLayout,
                 R.id.manual_carousel_filmstrip_center,
                 messageId,
                 deliveryId,
-                imageClickActions.get(newCenterIndex),
+                interactionUri,
                 tag,
                 sticky);
 
@@ -492,6 +504,7 @@ class FilmstripCarouselTemplateNotificationBuilder {
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TICKER, ticker);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.TAG, tag);
         clickIntent.putExtra(CampaignPushConstants.IntentKeys.STICKY, sticky);
+        clickIntent.putExtra(CampaignPushConstants.IntentKeys.ACTION_URI, fallbackActionUri);
 
         final PendingIntent pendingIntentLeftButton =
                 PendingIntent.getBroadcast(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fallback to the provided push template action uri for carousel items without a defined action uri. If no push template action uri is available then no action is taken when a carousel item is clicked.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
