### PR TITLE
Dev 2.1.4 to staging for 2.1.4 release

### DIFF
--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushConstants.java
@@ -52,7 +52,8 @@ final class CampaignPushConstants {
         static final String MANUAL_CAROUSEL_MODE = "manual";
         static final String FILMSTRIP_CAROUSEL_MODE = "filmstrip";
         static final int CAROUSEL_MINIMUM_IMAGE_COUNT = 3;
-        static final int CENTER_INDEX = 1;
+        static final int MANUAL_CAROUSEL_START_INDEX = 0;
+        static final int FILMSTRIP_CAROUSEL_CENTER_INDEX = 1;
         static final int ACTION_BUTTON_CAPACITY = 3;
         // TODO: revisit this value. should cache time be configurable rather than have a static
         // value?

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -146,13 +146,24 @@ public class CampaignPushTrackerActivity extends Activity {
             return;
         }
 
+        final NotificationManagerCompat notificationManager =
+                NotificationManagerCompat.from(context);
+        if (StringUtils.isNullOrEmpty(tag)) {
+            Log.warning(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "the sticky notification setting is false but the tag is null or empty,"
+                            + " default to removing all displayed notifications for %s.",
+                    getApplication().getPackageName());
+            notificationManager.cancelAll();
+            return;
+        }
+
         Log.trace(
                 CampaignPushConstants.LOG_TAG,
                 SELF_TAG,
                 "the sticky notification setting is false, removing notification with tag %s.",
                 tag);
-        final NotificationManagerCompat notificationManager =
-                NotificationManagerCompat.from(context);
         notificationManager.cancel(tag.hashCode());
     }
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/FilmstripCarouselTemplateNotificationBuilder.java
@@ -108,7 +108,8 @@ class FilmstripCarouselTemplateNotificationBuilder {
         // download the carousel images and populate the image uri, image caption, and image click
         // action arrays
         final int centerImageIndex =
-                CampaignPushConstants.DefaultValues.CENTER_INDEX; // center index defaults to 1
+                CampaignPushConstants.DefaultValues
+                        .FILMSTRIP_CAROUSEL_CENTER_INDEX; // center index defaults to 1
         final long imageProcessingStartTime = System.currentTimeMillis();
         final List<CarouselPushTemplate.CarouselItem> items = pushTemplate.getCarouselItems();
         final ArrayList<Bitmap> downloadedImages = new ArrayList<>();
@@ -425,11 +426,21 @@ class FilmstripCarouselTemplateNotificationBuilder {
                     SELF_TAG,
                     "Unable to calculate new left, center, and right indices. Using default center"
                             + " image index of 1.");
-            newCenterIndex = CampaignPushConstants.DefaultValues.CENTER_INDEX;
-            newLeftImage = cachedImages.get(CampaignPushConstants.DefaultValues.CENTER_INDEX - 1);
-            newCenterImage = cachedImages.get(CampaignPushConstants.DefaultValues.CENTER_INDEX);
-            newRightImage = cachedImages.get(CampaignPushConstants.DefaultValues.CENTER_INDEX + 1);
-            newCenterCaption = imageCaptions.get(CampaignPushConstants.DefaultValues.CENTER_INDEX);
+            newCenterIndex = CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_CENTER_INDEX;
+            newLeftImage =
+                    cachedImages.get(
+                            CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_CENTER_INDEX
+                                    - 1);
+            newCenterImage =
+                    cachedImages.get(
+                            CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_CENTER_INDEX);
+            newRightImage =
+                    cachedImages.get(
+                            CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_CENTER_INDEX
+                                    + 1);
+            newCenterCaption =
+                    imageCaptions.get(
+                            CampaignPushConstants.DefaultValues.FILMSTRIP_CAROUSEL_CENTER_INDEX);
         } else {
             newLeftIndex = newIndices.get(0);
             newCenterIndex = newIndices.get(1);

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/ManualCarouselTemplateNotificationBuilder.java
@@ -148,7 +148,8 @@ class ManualCarouselTemplateNotificationBuilder {
         expandedLayout.setTextViewText(R.id.notification_body_expanded, expandedBodyText);
 
         final int centerImageIndex =
-                CampaignPushConstants.DefaultValues.CENTER_INDEX; // center index defaults to 1
+                CampaignPushConstants.DefaultValues
+                        .MANUAL_CAROUSEL_START_INDEX; // start index defaults to 0
 
         // set any custom colors if needed
         AEPPushNotificationBuilder.setCustomNotificationColors(
@@ -364,7 +365,7 @@ class ManualCarouselTemplateNotificationBuilder {
         expandedLayout.setTextViewText(R.id.notification_body_expanded, expandedBodyText);
 
         final String action = intent.getAction();
-        int centerImageIndex =
+        final int centerImageIndex =
                 intentExtras.getInt(CampaignPushConstants.IntentKeys.CENTER_IMAGE_INDEX);
         final List<Integer> newIndices =
                 CampaignPushUtils.calculateNewIndices(centerImageIndex, imageUrls.size(), action);
@@ -374,9 +375,9 @@ class ManualCarouselTemplateNotificationBuilder {
             Log.trace(
                     CampaignPushConstants.LOG_TAG,
                     SELF_TAG,
-                    "Unable to calculate new left, center, and right indices. Using default center"
-                            + " image index of 1.");
-            newCenterIndex = CampaignPushConstants.DefaultValues.CENTER_INDEX;
+                    "Unable to calculate new left, center, and right indices. Using default start"
+                            + " image index of 0.");
+            newCenterIndex = CampaignPushConstants.DefaultValues.MANUAL_CAROUSEL_START_INDEX;
         } else {
             newCenterIndex = newIndices.get(1);
         }
@@ -546,7 +547,6 @@ class ManualCarouselTemplateNotificationBuilder {
                     new RemoteViews(packageName, R.layout.push_template_carousel_item);
             downloadedImageUris.add(imageUri);
             imageCaptions.add(item.getCaptionText());
-            imageClickActions.add(item.getInteractionUri());
             carouselItem.setImageViewBitmap(R.id.carousel_item_image_view, pushImage);
             carouselItem.setTextViewText(R.id.carousel_item_caption, item.getCaptionText());
 
@@ -555,6 +555,7 @@ class ManualCarouselTemplateNotificationBuilder {
                     !StringUtils.isNullOrEmpty(item.getInteractionUri())
                             ? item.getInteractionUri()
                             : actionUri;
+            imageClickActions.add(interactionUri);
             AEPPushNotificationBuilder.setRemoteViewClickAction(
                     context,
                     carouselItem,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add support for setting a large notification icon from a bundled drawable or a remote image url.
- Use the defined Push Template action URI for carousel items that do not have an action URI.
- Fix a NPE seen when a tag string was not provided for a basic template notification.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
