### PR TITLE
Fix activity started from deeplink from being recreated

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.5";
+    static final String EXTENSION_VERSION = "2.1.6";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -204,7 +204,7 @@ public class CampaignPushTrackerActivity extends Activity {
     private void openUri(final String uri) {
         try {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
         } catch (final ActivityNotFoundException e) {
             Log.warning(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -204,6 +204,7 @@ public class CampaignPushTrackerActivity extends Activity {
     private void openUri(final String uri) {
         try {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             startActivity(intent);
         } catch (ActivityNotFoundException e) {
             Log.warning(

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -206,7 +206,7 @@ public class CampaignPushTrackerActivity extends Activity {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             startActivity(intent);
-        } catch (ActivityNotFoundException e) {
+        } catch (final ActivityNotFoundException e) {
             Log.warning(
                     CampaignPushConstants.LOG_TAG,
                     SELF_TAG,

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -11,7 +11,6 @@
 package com.adobe.marketing.mobile;
 
 import android.app.Activity;
-import android.app.TaskStackBuilder;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/CampaignPushTrackerActivity.java
@@ -12,6 +12,7 @@ package com.adobe.marketing.mobile;
 
 import android.app.Activity;
 import android.app.TaskStackBuilder;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -202,9 +203,15 @@ public class CampaignPushTrackerActivity extends Activity {
      * @param uri the uri to open
      */
     private void openUri(final String uri) {
-        final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
-        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
-        stackBuilder.addNextIntentWithParentStack(intent);
-        stackBuilder.startActivities();
+        try {
+            final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+            startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            Log.warning(
+                    CampaignPushConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Unable to open the URI from the notification interaction. URI: %s",
+                    uri);
+        }
     }
 }

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -23,7 +23,7 @@ public class CampaignClassic {
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
 
-    static final String EXTENSION_VERSION = "2.1.5";
+    static final String EXTENSION_VERSION = "2.1.6";
     static final String REGISTER_DEVICE = "registerdevice";
     static final String TRACK_RECEIVE = "trackreceive";
     static final String TRACK_CLICK = "trackclick";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.5";
+    static final String EXTENSION_VERSION = "2.1.6";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.configureondemand=false
 
 moduleProjectName=campaignclassic
 moduleName=campaignclassic
-moduleVersion=2.1.5
+moduleVersion=2.1.6
 moduleAARName=campaignclassic-phone-release.aar
 
 #Maven artifact


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

TaskStackBuilder used by NotificationManager always adds the following flags to the launch intent: `NEW_TASK | CLEAR_TASK | TASK_ON_HOME `. This causes the activity launched by a deeplink to be recreated instead of being resumed. Porting the fix from Messaging to resolve the issue.

https://github.com/adobe/aepsdk-messaging-android/pull/242/files

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
