### PR TITLE
remove the SCHEDULE_EXACT_ALARM permission from the ACC extension

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.6";
+    static final String EXTENSION_VERSION = "2.1.7";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/AndroidManifest.xml
+++ b/code/campaignclassic/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.adobe.marketing.mobile.campaignclassic" >
 
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application>
         <activity
         android:name="com.adobe.marketing.mobile.CampaignPushTrackerActivity"

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplateBroadcastReceiver.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/AEPPushTemplateBroadcastReceiver.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import com.adobe.marketing.mobile.util.StringUtils;
 
 /** Broadcast receiver for handling custom push template notification interactions. */
@@ -36,9 +35,7 @@ public class AEPPushTemplateBroadcastReceiver extends BroadcastReceiver {
                 ManualCarouselTemplateNotificationBuilder.handleIntent(context, intent);
                 break;
             case CampaignPushConstants.IntentActions.REMIND_LATER_CLICKED:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    BasicTemplateNotificationBuilder.handleRemindIntent(context, intent);
-                }
+                BasicTemplateNotificationBuilder.handleRemindIntent(context, intent);
                 break;
             case CampaignPushConstants.IntentActions.SCHEDULED_NOTIFICATION_BROADCAST:
                 BasicTemplateNotificationBuilder.handleScheduledIntent(context, intent);

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -23,7 +23,7 @@ public class CampaignClassic {
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
 
-    static final String EXTENSION_VERSION = "2.1.6";
+    static final String EXTENSION_VERSION = "2.1.7";
     static final String REGISTER_DEVICE = "registerdevice";
     static final String TRACK_RECEIVE = "trackreceive";
     static final String TRACK_CLICK = "trackclick";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.6";
+    static final String EXTENSION_VERSION = "2.1.7";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.configureondemand=false
 
 moduleProjectName=campaignclassic
 moduleName=campaignclassic
-moduleVersion=2.1.6
+moduleVersion=2.1.7
 moduleAARName=campaignclassic-phone-release.aar
 
 #Maven artifact

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     package="com.adobe.campaignclassictestapp">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- If the API level is S / 31 or higher, the acc extension should check if the SCHEDULE_EXACT_ALARM permission is given to the app. Scheduled notifications are then scheduled with exact timestamps If SCHEDULE_EXACT_ALARM is granted. If an API less than S / 31 is in use, or the exact alarm permission wasn't granted to the app, then an inexact alarm is used instead. Inexact scheduling will display the scheduled notification within a 1 hour window starting with the given timestamp.
- update the test app to display an alert dialog prompting the app user to allow exact alarm permission
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
