### PR TITLE
Fix clipped captions in carousel push templates

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.7";
+    static final String EXTENSION_VERSION = "2.1.8";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/campaignclassic/src/main/res/layout/push_template_auto_carousel.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_auto_carousel.xml
@@ -1,47 +1,52 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
     android:clipChildren="false"
+    android:clipToPadding="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
 
-    <ImageView
-        android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
-        android:layout_alignParentRight="true" />
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/notification_title"
-        style="@style/Title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_toLeftOf="@+id/large_icon"/>
+        <ImageView
+            android:id="@+id/large_icon"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_alignParentRight="true" />
 
-    <TextView
-        android:id="@+id/notification_body_expanded"
-        style="@style/Body"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_below="@id/notification_title"
-        android:layout_toLeftOf="@+id/large_icon"/>
+        <TextView
+            android:id="@+id/notification_title"
+            style="@style/Title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
+
+        <TextView
+            android:id="@+id/notification_body_expanded"
+            style="@style/Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/notification_title"
+            android:layout_alignParentStart="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
+    </RelativeLayout>
 
     <ViewFlipper
         android:id="@+id/auto_carousel_view_flipper"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
         android:autoStart="true"
         android:flipInterval="5000"
-        android:scaleType="fitCenter"
-        android:adjustViewBounds="true"
-        android:layout_below="@id/notification_body_expanded"
         android:inAnimation="@android:anim/slide_in_left"
-        android:outAnimation="@android:anim/slide_out_right"/>
-</RelativeLayout>
+        android:outAnimation="@android:anim/slide_out_right"
+        android:scaleType="fitCenter" />
+</LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,7 +10,8 @@
 
     <ImageView
         android:id="@+id/carousel_item_image_view"
-        android:layout_centerHorizontal="true"
+        android:layout_weight=".9"
+        android:gravity="center_horizontal"
         android:layout_width="250dp"
         android:scaleType="fitCenter"
         android:adjustViewBounds="true"
@@ -20,9 +21,9 @@
     <TextView
         android:id="@+id/carousel_item_caption"
         style="@style/Caption"
+        android:layout_weight=".1"
+        android:gravity="center_horizontal"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/carousel_item_image_view"
-        android:layout_centerHorizontal="true"
         android:layout_gravity="center" />
-</RelativeLayout>
+</LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
@@ -3,27 +3,26 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
     android:clipChildren="false"
+    android:clipToPadding="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
 
     <ImageView
         android:id="@+id/carousel_item_image_view"
-        android:layout_weight=".9"
-        android:gravity="center_horizontal"
         android:layout_width="250dp"
-        android:scaleType="fitCenter"
-        android:adjustViewBounds="true"
+        android:layout_height="0dp"
         android:layout_gravity="center"
-        android:layout_height="200dp" />
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:gravity="center_horizontal"
+        android:scaleType="fitCenter" />
 
     <TextView
         android:id="@+id/carousel_item_caption"
         style="@style/Caption"
-        android:layout_weight=".1"
-        android:gravity="center_horizontal"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:gravity="center_horizontal" />
 </LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
@@ -10,7 +10,7 @@
 
     <ImageView
         android:id="@+id/carousel_item_image_view"
-        android:layout_width="250dp"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_gravity="center"
         android:layout_weight="1"
@@ -22,7 +22,5 @@
         android:id="@+id/carousel_item_caption"
         style="@style/Caption"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center_horizontal" />
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_carousel_item.xml
@@ -22,5 +22,6 @@
         android:id="@+id/carousel_item_caption"
         style="@style/Caption"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
 </LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
@@ -1,110 +1,114 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
     android:clipChildren="false"
+    android:clipToPadding="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
-    <ImageView
-        android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
-        android:layout_alignParentRight="true" />
 
-    <TextView
-        android:id="@+id/notification_title"
-        style="@style/Title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_toLeftOf="@+id/large_icon"/>
-
-    <TextView
-        android:id="@+id/notification_body_expanded"
-        style="@style/Body"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/notification_title"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_toLeftOf="@+id/large_icon"/>
-
-    <LinearLayout
-        android:id="@+id/manual_carousel_filmstrip_center_layout"
+    <RelativeLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        android:clipChildren="false"
-        android:orientation="vertical"
-        android:layout_centerHorizontal="true"
-        android:layout_below="@id/notification_body_expanded"
-        android:theme="@style/DayNightTheme">
+        android:layout_height="wrap_content">
 
-    <ImageView
-        android:id="@+id/manual_carousel_filmstrip_center"
-        android:scaleType="fitCenter"
-        android:adjustViewBounds="true"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
-        android:layout_weight=".9"
-        android:gravity="center_horizontal">
-    </ImageView>
+        <ImageView
+            android:id="@+id/large_icon"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_alignParentEnd="true" />
 
-    <TextView
-        android:id="@+id/manual_carousel_filmstrip_caption"
-        style="@style/Caption"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight=".1"
-        android:gravity="center_horizontal"
-        android:layout_gravity="center" />
-    </LinearLayout>
+        <TextView
+            android:id="@+id/notification_title"
+            style="@style/Title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
 
+        <TextView
+            android:id="@+id/notification_body_expanded"
+            style="@style/Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/notification_title"
+            android:layout_alignParentStart="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
+    </RelativeLayout>
 
-    <ImageView
-        android:id="@+id/manual_carousel_filmstrip_left"
-        android:scaleType="centerCrop"
-        android:adjustViewBounds="true"
-        android:layout_gravity="center_vertical"
-        android:layout_centerHorizontal="true"
-        android:layout_width="100dp"
-        android:layout_height="150dp"
-        android:layout_marginRight="2dp"
-        android:layout_marginTop="15dp"
-        android:layout_toStartOf="@id/manual_carousel_filmstrip_center_layout"
-        android:layout_below="@id/notification_body_expanded">
-    </ImageView>
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_weight="0.1">
 
-    <ImageView
-        android:id="@+id/manual_carousel_filmstrip_right"
-        android:scaleType="centerCrop"
-        android:adjustViewBounds="true"
-        android:layout_gravity="center_vertical"
-        android:layout_centerHorizontal="true"
-        android:layout_width="100dp"
-        android:layout_height="150dp"
-        android:layout_marginLeft="2dp"
-        android:layout_marginTop="15dp"
-        android:layout_toEndOf="@id/manual_carousel_filmstrip_center_layout"
-        android:layout_below="@id/notification_body_expanded">
-    </ImageView>
+        <LinearLayout
+            android:id="@+id/manual_carousel_filmstrip_center_layout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:clipChildren="false"
+            android:clipToPadding="false"
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
 
-    <ImageButton
-        android:id="@+id/leftImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
-        android:layout_centerVertical="true"
-        android:layout_alignParentLeft="true"
-        android:background="@drawable/skipleft" />
+            <ImageView
+                android:id="@+id/manual_carousel_filmstrip_center"
+                android:layout_width="200dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:adjustViewBounds="true"
+                android:gravity="center_horizontal"
+                android:scaleType="fitCenter"></ImageView>
 
-    <ImageButton
-        android:id="@+id/rightImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
-        android:layout_centerVertical="true"
-        android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
-        android:background="@drawable/skipright" />
-</RelativeLayout>
+            <TextView
+                android:id="@+id/manual_carousel_filmstrip_caption"
+                style="@style/Caption"
+                android:layout_width="175dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center_horizontal" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/manual_carousel_filmstrip_left"
+            android:layout_width="100dp"
+            android:layout_height="150dp"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="15dp"
+            android:layout_marginEnd="2dp"
+            android:layout_toStartOf="@id/manual_carousel_filmstrip_center_layout"
+            android:adjustViewBounds="false"
+            android:scaleType="centerCrop" />
+
+        <ImageView
+            android:id="@+id/manual_carousel_filmstrip_right"
+            android:layout_width="100dp"
+            android:layout_height="150dp"
+            android:layout_centerHorizontal="true"
+            android:layout_marginStart="2dp"
+            android:layout_marginTop="15dp"
+            android:layout_toEndOf="@id/manual_carousel_filmstrip_center_layout"
+            android:adjustViewBounds="false"
+            android:scaleType="centerCrop" />
+
+        <ImageButton
+            android:id="@+id/leftImageButton"
+            android:layout_width="15dp"
+            android:layout_height="20dp"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:background="@drawable/skipleft" />
+
+        <ImageButton
+            android:id="@+id/rightImageButton"
+            android:layout_width="15dp"
+            android:layout_height="20dp"
+            android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
+            android:layout_centerVertical="true"
+            android:background="@drawable/skipright" />
+    </RelativeLayout>
+</LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
@@ -3,8 +3,8 @@
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipChildren="false"
     android:clipToPadding="false"
+    android:clipChildren="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
 
@@ -23,92 +23,85 @@
             style="@style/Title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
+            android:textAlignment="viewStart"
             android:layout_toLeftOf="@+id/large_icon"
-            android:textAlignment="viewStart" />
+            android:layout_alignParentTop="true"
+            android:layout_alignParentStart="true"/>
 
         <TextView
             android:id="@+id/notification_body_expanded"
             style="@style/Body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:textAlignment="viewStart"
             android:layout_below="@id/notification_title"
-            android:layout_alignParentStart="true"
             android:layout_toLeftOf="@+id/large_icon"
-            android:textAlignment="viewStart" />
+            android:layout_alignParentStart="true"/>
     </RelativeLayout>
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_gravity="center_horizontal"
-        android:layout_weight="0.1">
+        android:layout_weight="1">
 
-        <LinearLayout
-            android:id="@+id/manual_carousel_filmstrip_center_layout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:clipChildren="false"
-            android:clipToPadding="false"
-            android:gravity="center_horizontal"
-            android:orientation="vertical">
-
-            <ImageView
-                android:id="@+id/manual_carousel_filmstrip_center"
-                android:layout_width="200dp"
-                android:layout_height="0dp"
-                android:layout_weight="1"
-                android:adjustViewBounds="true"
-                android:gravity="center_horizontal"
-                android:scaleType="fitCenter"></ImageView>
-
-            <TextView
-                android:id="@+id/manual_carousel_filmstrip_caption"
-                style="@style/Caption"
-                android:layout_width="175dp"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:gravity="center_horizontal" />
-        </LinearLayout>
+        <ImageView
+            android:id="@+id/manual_carousel_filmstrip_center"
+            android:scaleType="fitCenter"
+            android:adjustViewBounds="true"
+            android:layout_width="200dp"
+            android:layout_height="match_parent"
+            android:layout_centerHorizontal="true">
+        </ImageView>
 
         <ImageView
             android:id="@+id/manual_carousel_filmstrip_left"
-            android:layout_width="100dp"
-            android:layout_height="150dp"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true"
+            android:layout_gravity="center"
             android:layout_centerHorizontal="true"
-            android:layout_marginTop="15dp"
-            android:layout_marginEnd="2dp"
-            android:layout_toStartOf="@id/manual_carousel_filmstrip_center_layout"
-            android:adjustViewBounds="false"
-            android:scaleType="centerCrop" />
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:layout_marginRight="2dp"
+            android:layout_marginTop="25dp"
+            android:layout_marginBottom="12dp"
+            android:layout_toLeftOf="@id/manual_carousel_filmstrip_center">
+        </ImageView>
 
         <ImageView
             android:id="@+id/manual_carousel_filmstrip_right"
-            android:layout_width="100dp"
-            android:layout_height="150dp"
+            android:scaleType="centerCrop"
+            android:adjustViewBounds="true"
+            android:layout_gravity="center"
             android:layout_centerHorizontal="true"
-            android:layout_marginStart="2dp"
-            android:layout_marginTop="15dp"
-            android:layout_toEndOf="@id/manual_carousel_filmstrip_center_layout"
-            android:adjustViewBounds="false"
-            android:scaleType="centerCrop" />
+            android:layout_width="100dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="2dp"
+            android:layout_marginTop="25dp"
+            android:layout_marginBottom="12dp"
+            android:layout_toRightOf="@id/manual_carousel_filmstrip_center">
+        </ImageView>
 
         <ImageButton
             android:id="@+id/leftImageButton"
             android:layout_width="15dp"
             android:layout_height="20dp"
-            android:layout_alignParentLeft="true"
             android:layout_centerVertical="true"
+            android:layout_alignParentLeft="true"
             android:background="@drawable/skipleft" />
 
         <ImageButton
             android:id="@+id/rightImageButton"
             android:layout_width="15dp"
             android:layout_height="20dp"
-            android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
             android:layout_centerVertical="true"
+            android:layout_alignEnd="@id/manual_carousel_filmstrip_right"
             android:background="@drawable/skipright" />
     </RelativeLayout>
+
+    <TextView
+        android:id="@+id/manual_carousel_filmstrip_caption"
+        style="@style/Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
 </LinearLayout>

--- a/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_filmstrip_carousel.xml
@@ -7,7 +7,6 @@
     android:clipChildren="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
-
     <ImageView
         android:id="@+id/large_icon"
         android:layout_height="35dp"
@@ -33,14 +32,25 @@
         android:textAlignment="viewStart"
         android:layout_toLeftOf="@+id/large_icon"/>
 
+    <LinearLayout
+        android:id="@+id/manual_carousel_filmstrip_center_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:clipChildren="false"
+        android:orientation="vertical"
+        android:layout_centerHorizontal="true"
+        android:layout_below="@id/notification_body_expanded"
+        android:theme="@style/DayNightTheme">
+
     <ImageView
         android:id="@+id/manual_carousel_filmstrip_center"
         android:scaleType="fitCenter"
         android:adjustViewBounds="true"
         android:layout_width="200dp"
         android:layout_height="200dp"
-        android:layout_centerHorizontal="true"
-        android:layout_below="@id/notification_body_expanded">
+        android:layout_weight=".9"
+        android:gravity="center_horizontal">
     </ImageView>
 
     <TextView
@@ -48,21 +58,23 @@
         style="@style/Caption"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/manual_carousel_filmstrip_center"
-        android:layout_centerHorizontal="true"
+        android:layout_weight=".1"
+        android:gravity="center_horizontal"
         android:layout_gravity="center" />
+    </LinearLayout>
+
 
     <ImageView
         android:id="@+id/manual_carousel_filmstrip_left"
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
-        android:layout_gravity="center"
+        android:layout_gravity="center_vertical"
         android:layout_centerHorizontal="true"
         android:layout_width="100dp"
-        android:layout_height="175dp"
+        android:layout_height="150dp"
         android:layout_marginRight="2dp"
         android:layout_marginTop="15dp"
-        android:layout_toLeftOf="@id/manual_carousel_filmstrip_center"
+        android:layout_toStartOf="@id/manual_carousel_filmstrip_center_layout"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
 
@@ -70,13 +82,13 @@
         android:id="@+id/manual_carousel_filmstrip_right"
         android:scaleType="centerCrop"
         android:adjustViewBounds="true"
-        android:layout_gravity="center"
+        android:layout_gravity="center_vertical"
         android:layout_centerHorizontal="true"
         android:layout_width="100dp"
-        android:layout_height="175dp"
+        android:layout_height="150dp"
         android:layout_marginLeft="2dp"
         android:layout_marginTop="15dp"
-        android:layout_toRightOf="@id/manual_carousel_filmstrip_center"
+        android:layout_toEndOf="@id/manual_carousel_filmstrip_center_layout"
         android:layout_below="@id/notification_body_expanded">
     </ImageView>
 

--- a/code/campaignclassic/src/main/res/layout/push_template_manual_carousel.xml
+++ b/code/campaignclassic/src/main/res/layout/push_template_manual_carousel.xml
@@ -1,60 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/carousel_container_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:clipToPadding="false"
     android:clipChildren="false"
+    android:clipToPadding="false"
     android:orientation="vertical"
     android:theme="@style/DayNightTheme">
 
-    <ImageView
-        android:id="@+id/large_icon"
-        android:layout_height="35dp"
-        android:layout_width="35dp"
-        android:layout_alignParentRight="true" />
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/notification_title"
-        style="@style/Title"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_toLeftOf="@+id/large_icon"/>
+        <ImageView
+            android:id="@+id/large_icon"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_alignParentEnd="true" />
 
-    <TextView
-        android:id="@+id/notification_body_expanded"
-        style="@style/Body"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:textAlignment="viewStart"
-        android:layout_below="@id/notification_title"
-        android:layout_toLeftOf="@+id/large_icon"/>
+        <TextView
+            android:id="@+id/notification_title"
+            style="@style/Title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
 
-    <ViewFlipper
-        android:id="@+id/manual_carousel_view_flipper"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:scaleType="fitCenter"
-        android:layout_below="@id/notification_body_expanded"
-        android:adjustViewBounds="true">
-    </ViewFlipper>
+        <TextView
+            android:id="@+id/notification_body_expanded"
+            style="@style/Body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/notification_title"
+            android:layout_alignParentStart="true"
+            android:layout_toLeftOf="@+id/large_icon"
+            android:textAlignment="viewStart" />
+    </RelativeLayout>
 
-    <ImageButton
-        android:id="@+id/leftImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
-        android:layout_centerVertical="true"
-        android:layout_alignParentStart="true"
-        android:background="@drawable/skipleft" />
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
-    <ImageButton
-        android:id="@+id/rightImageButton"
-        android:layout_width="15dp"
-        android:layout_height="20dp"
-        android:layout_centerVertical="true"
-        android:layout_alignEnd="@id/manual_carousel_view_flipper"
-        android:background="@drawable/skipright" />
-</RelativeLayout>
+        <ViewFlipper
+            android:id="@+id/manual_carousel_view_flipper"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter" />
+
+        <ImageButton
+            android:id="@+id/leftImageButton"
+            android:layout_width="15dp"
+            android:layout_height="20dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:background="@drawable/skipleft" />
+
+        <ImageButton
+            android:id="@+id/rightImageButton"
+            android:layout_width="15dp"
+            android:layout_height="20dp"
+            android:layout_alignEnd="@id/manual_carousel_view_flipper"
+            android:layout_centerVertical="true"
+            android:background="@drawable/skipright" />
+
+    </RelativeLayout>
+</LinearLayout>

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -23,7 +23,7 @@ public class CampaignClassic {
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
 
-    static final String EXTENSION_VERSION = "2.1.7";
+    static final String EXTENSION_VERSION = "2.1.8";
     static final String REGISTER_DEVICE = "registerdevice";
     static final String TRACK_RECEIVE = "trackreceive";
     static final String TRACK_CLICK = "trackclick";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.campaignclassic.internal;
 /** This class holds all test constant values used only by the Campaign Classic extension */
 final class CampaignClassicTestConstants {
 
-    static final String EXTENSION_VERSION = "2.1.7";
+    static final String EXTENSION_VERSION = "2.1.8";
 
     private CampaignClassicTestConstants() {}
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.configureondemand=false
 
 moduleProjectName=campaignclassic
 moduleName=campaignclassic
-moduleVersion=2.1.7
+moduleVersion=2.1.8
 moduleAARName=campaignclassic-phone-release.aar
 
 #Maven artifact


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix carousel captions from being clipped on devices with smaller screens.
**2.1.7:**
<img src="https://github.com/adobe/aepsdk-campaignclassic-android/assets/11319121/8e48567a-2be7-4211-8d46-1c1717c28259" width="200" height="400"/>

**2.1.8:**
<img src="https://github.com/adobe/aepsdk-campaignclassic-android/assets/11319121/e6d795b9-0b31-4ef8-944a-8b2752c46b39" width="200" height="400"/>
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
