### PR TITLE
fix handling of negative 32-bit broadlog id's

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicIntegrationTests.kt
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicIntegrationTests.kt
@@ -748,39 +748,8 @@ class CampaignClassicIntegrationTests {
     // =================================================================================================================
     // void trackNotificationReceive(final Map<String, String> trackInfo)
     // =================================================================================================================
-
     @Test
-    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhenAllParametersArePresentV7() {
-        // setup
-        val countDownLatch = CountDownLatch(1)
-        val configurationLatch = CountDownLatch(1)
-        configurationAwareness { configurationLatch.countDown() }
-        setupConfiguration()
-
-        // test
-        CampaignClassic.trackNotificationReceive(
-            mapOf(
-                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to "testDeliveryId",
-                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to "12345"
-            )
-        )
-
-        // verify
-        networkMonitor = { request ->
-            // verify network request url
-            val messageId = java.lang.String.format("%x", 12345)
-            Assert.assertEquals(
-                "https://testTrackingServer/r/?id=h$messageId,testDeliveryId,1",
-                request.url
-            )
-
-            countDownLatch.countDown()
-        }
-        Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
-    }
-
-    @Test
-    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhenBroadLogIdIs64BitV7() {
+    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhen64BitBroadLogId() {
         // setup
         val countDownLatch = CountDownLatch(1)
         val configurationLatch = CountDownLatch(1)
@@ -810,7 +779,67 @@ class CampaignClassicIntegrationTests {
     }
 
     @Test
-    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhenAllParametersArePresentV8() {
+    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhen32BitNegativeBroadLogId() {
+        // setup
+        val countDownLatch = CountDownLatch(1)
+        val configurationLatch = CountDownLatch(1)
+        configurationAwareness { configurationLatch.countDown() }
+        setupConfiguration()
+
+        // test
+        CampaignClassic.trackNotificationReceive(
+            mapOf(
+                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to "testDeliveryId",
+                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to "-1709416000"
+            )
+        )
+
+        // verify
+        networkMonitor = { request ->
+            // verify network request url
+            val messageId = java.lang.String.format("%x", -1709416000)
+            Assert.assertEquals(
+                "https://testTrackingServer/r/?id=h$messageId,testDeliveryId,1",
+                request.url
+            )
+
+            countDownLatch.countDown()
+        }
+        Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhen32BitBroadLogId() {
+        // setup
+        val countDownLatch = CountDownLatch(1)
+        val configurationLatch = CountDownLatch(1)
+        configurationAwareness { configurationLatch.countDown() }
+        setupConfiguration()
+
+        // test
+        CampaignClassic.trackNotificationReceive(
+            mapOf(
+                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to "testDeliveryId",
+                CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to "1709416000"
+            )
+        )
+
+        // verify
+        networkMonitor = { request ->
+            // verify network request url
+            val messageId = java.lang.String.format("%x", 1709416000)
+            Assert.assertEquals(
+                "https://testTrackingServer/r/?id=h$messageId,testDeliveryId,1",
+                request.url
+            )
+
+            countDownLatch.countDown()
+        }
+        Assert.assertTrue(countDownLatch.await(3, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun test_trackNotificationReceive_VerifyTrackNotificationReceiveRequestSentWhenAllParametersArePresentUUIDBroadlog() {
         // setup
         val countDownLatch = CountDownLatch(1)
         val configurationLatch = CountDownLatch(1)
@@ -1245,7 +1274,7 @@ class CampaignClassicIntegrationTests {
     }
 
     @Test
-    fun test_trackNotificationClick_VerifyTrackNotificationClickRequestSentWhenAllParametersArePresentV8() {
+    fun test_trackNotificationClick_VerifyTrackNotificationClickRequestSentWhenAllParametersArePresentUUID() {
         // setup
         val countDownLatch = CountDownLatch(1)
         val configurationLatch = CountDownLatch(1)

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/CampaignClassic.java
@@ -26,7 +26,7 @@ public class CampaignClassic {
      */
     public static final Class<? extends Extension> EXTENSION = CampaignClassicExtension.class;
 
-    public static final String EXTENSION_VERSION = "3.1.3";
+    public static final String EXTENSION_VERSION = "3.1.4";
     private static final String LOG_TAG = "CampaignClassicExtension";
     private static final String SELF_TAG = "CampaignClassic";
     static final String REGISTER_DEVICE = "registerdevice";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
@@ -412,6 +412,124 @@ class TrackRequestManagerTests {
     }
 
     // =================================================================================================================
+    // 32-bit negative and 64-bit message id tests
+    // =================================================================================================================
+    @Test
+    fun handleTrackRequest_NotificationReceived_Negative32BitMessageId() {
+        // setup
+        setConfigurationSharedState()
+
+        // test
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "-673096100"),
+            CampaignClassicTestConstants.MESSAGE_RECEIVED_TAGID
+        )
+
+        // verify network call
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+
+        // verify url
+        val expectedUrl = "https://testTrackingServer/r/?id=h${java.lang.String.format("%x", -673096100)},testDeliveryId,1"
+        Assert.assertEquals(expectedUrl, networkRequestCaptor.value.url)
+        Assert.assertEquals(CampaignClassicTestConstants.DEFAULT_TIMEOUT, networkRequestCaptor.value.connectTimeout)
+        Assert.assertNull(networkRequestCaptor.value.body)
+    }
+
+    @Test
+    fun handleTrackRequest_NotificationReceived_32BitMessageId() {
+        // setup
+        setConfigurationSharedState()
+
+        // test
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "673096100"),
+            CampaignClassicTestConstants.MESSAGE_RECEIVED_TAGID
+        )
+
+        // verify network call
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+
+        // verify url
+        val expectedUrl = "https://testTrackingServer/r/?id=h${java.lang.String.format("%x", 673096100)},testDeliveryId,1"
+        Assert.assertEquals(expectedUrl, networkRequestCaptor.value.url)
+        Assert.assertEquals(CampaignClassicTestConstants.DEFAULT_TIMEOUT, networkRequestCaptor.value.connectTimeout)
+        Assert.assertNull(networkRequestCaptor.value.body)
+    }
+
+    @Test
+    fun handleTrackRequest_NotificationReceived_64BitMessageId() {
+        // setup
+        setConfigurationSharedState()
+
+        // test
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "57904851586134"),
+            CampaignClassicTestConstants.MESSAGE_RECEIVED_TAGID
+        )
+
+        // verify network call
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+
+        // verify url
+        val expectedUrl = "https://testTrackingServer/r/?id=h${java.lang.String.format("%x", 57904851586134)},testDeliveryId,1"
+        Assert.assertEquals(expectedUrl, networkRequestCaptor.value.url)
+        Assert.assertEquals(CampaignClassicTestConstants.DEFAULT_TIMEOUT, networkRequestCaptor.value.connectTimeout)
+        Assert.assertNull(networkRequestCaptor.value.body)
+    }
+
+    @Test
+    fun handleTrackRequest_NotificationReceived_64BitMessageId_MinimumValue() {
+        // setup
+        setConfigurationSharedState()
+
+        // test
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "2147483648"),
+            CampaignClassicTestConstants.MESSAGE_RECEIVED_TAGID
+        )
+
+        // verify network call
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+
+        // verify url
+        val expectedUrl = "https://testTrackingServer/r/?id=h${java.lang.String.format("%x", 2147483648)},testDeliveryId,1"
+        Assert.assertEquals(expectedUrl, networkRequestCaptor.value.url)
+        Assert.assertEquals(CampaignClassicTestConstants.DEFAULT_TIMEOUT, networkRequestCaptor.value.connectTimeout)
+        Assert.assertNull(networkRequestCaptor.value.body)
+    }
+
+    @Test
+    fun handleTrackRequest_NotificationReceived_64BitMessageId_MaxValue() {
+        // setup
+        setConfigurationSharedState()
+
+        // test
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "9223372036854775807"),
+            CampaignClassicTestConstants.MESSAGE_RECEIVED_TAGID
+        )
+
+        // verify network call
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+
+        // verify url
+        val expectedUrl = "https://testTrackingServer/r/?id=h${java.lang.String.format("%x", 9223372036854775807L)},testDeliveryId,1"
+        Assert.assertEquals(expectedUrl, networkRequestCaptor.value.url)
+        Assert.assertEquals(CampaignClassicTestConstants.DEFAULT_TIMEOUT, networkRequestCaptor.value.connectTimeout)
+        Assert.assertNull(networkRequestCaptor.value.body)
+    }
+
+    // =================================================================================================================
     // private methods
     // =================================================================================================================
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 moduleName=campaignclassic
-moduleVersion=3.1.3
+moduleVersion=3.1.4
 
 #Maven artifact
 mavenRepoName=AdobeMobileCampaignClassicSdk


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
All non UUID broadlog id's were being converted to long before being converted to hex. this was causing the hex encoded values to contain sign extension to fill the 64-bit variable. Negative broadlog id's will be 32-bit values only and 64-bit broadlog id's will not use negative values. To resolve the bug, negative 32-bit broadlog values will be converted to int instead of long prior to hex conversion to prevent the sign extension from occurring.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
