### PR TITLE
Multiple Tracking Server support - RT + Martketting

### DIFF
--- a/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/androidTest/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -52,6 +52,7 @@ final class CampaignClassicTestConstants {
 
             static final String TRACK_INFO_KEY_MESSAGE_ID = "_mId";
             static final String TRACK_INFO_KEY_DELIVERY_ID = "_dId";
+            static final String TRACK_INFO_KEY_TRACKING_INSTANCE_ID = "_iNm";
 
             private CampaignClassic() {}
         }

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfiguration.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfiguration.kt
@@ -15,8 +15,10 @@ import com.adobe.marketing.mobile.Event
 import com.adobe.marketing.mobile.ExtensionApi
 import com.adobe.marketing.mobile.MobilePrivacyStatus
 import com.adobe.marketing.mobile.SharedStateResolution
+import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.util.DataReader
 import com.adobe.marketing.mobile.util.DataReaderException
+import org.json.JSONArray
 
 internal data class CampaignClassicConfiguration(val event: Event, val extensionApi: ExtensionApi) {
 
@@ -79,6 +81,46 @@ internal data class CampaignClassicConfiguration(val event: Event, val extension
             } else {
                 trackingServer
             }
+        }
+
+    /**
+     * @return configured CampaignClassics tracking server [String] if available, not null and not empty,
+     * and of type String, null otherwise
+     */
+    val trackingEndpointsMapping: String?
+        get() {
+            val trackingEndpointsMapping = DataReader.optString(
+                configSharedState,
+                CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING,
+                null
+            )
+            return if (trackingEndpointsMapping.isNullOrBlank()) {
+                null
+            } else {
+                trackingEndpointsMapping
+            }
+        }
+
+    val trackingEndpointsMap: Map<String, String>
+        get() {
+            val result = mutableMapOf<String, String>()
+            val mappingStr = trackingEndpointsMapping
+            if (mappingStr.isNullOrBlank()) return result
+            try {
+                val jsonArray = JSONArray(mappingStr)
+                for (i in 0 until jsonArray.length()) {
+                    val obj = jsonArray.optJSONObject(i)
+                    val identifier = obj?.optString(CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_OBJECT_ID)
+                    val endpoint = obj?.optString(CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_OBJECT_ENDPOINT)
+                    if (!identifier.isNullOrBlank() && !endpoint.isNullOrBlank()) {
+                        result[identifier] = endpoint
+                    }
+                }
+            } catch (e: Exception) {
+                // Malformed JSON, return empty map
+                Log.debug(CampaignClassicConstants.LOG_TAG, "CampaignClassicConfiguration", "trackingEndpointsMappingMap: Malformed JSON")
+            }
+            return result
         }
 
     /**

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConstants.java
@@ -55,7 +55,8 @@ final class CampaignClassicConstants {
             static final String CAMPAIGNCLASSIC_MARKETING_SERVER =
                     "campaignclassic.marketingServer";
             static final String CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer";
-            static final String CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointsMapping";
+            static final String CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING =
+                    "campaignclassic.trackingEndpointsMapping";
             static final String CAMPAIGNCLASSIC_TRACKING_OBJECT_ID = "identifier";
             static final String CAMPAIGNCLASSIC_TRACKING_OBJECT_ENDPOINT = "endpoint";
             static final String CAMPAIGNCLASSIC_APP_INTEGRATION_KEY =

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConstants.java
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConstants.java
@@ -55,6 +55,9 @@ final class CampaignClassicConstants {
             static final String CAMPAIGNCLASSIC_MARKETING_SERVER =
                     "campaignclassic.marketingServer";
             static final String CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer";
+            static final String CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING = "campaignclassic.trackingEndpointsMapping";
+            static final String CAMPAIGNCLASSIC_TRACKING_OBJECT_ID = "identifier";
+            static final String CAMPAIGNCLASSIC_TRACKING_OBJECT_ENDPOINT = "endpoint";
             static final String CAMPAIGNCLASSIC_APP_INTEGRATION_KEY =
                     "campaignclassic.android.integrationKey";
             static final String CAMPAIGNCLASSIC_TIMEOUT = "campaignclassic.timeout";
@@ -70,6 +73,7 @@ final class CampaignClassicConstants {
             static final String TRACK_INFO = "trackinfo";
             static final String TRACK_INFO_KEY_MESSAGE_ID = "_mId";
             static final String TRACK_INFO_KEY_DELIVERY_ID = "_dId";
+            static final String TRACK_INFO_KEY_TRACKING_INSTANCE_ID = "_iNm";
             static final String DEVICE_TOKEN = "devicetoken";
             static final String USER_KEY = "userkey";
             static final String ADDITIONAL_PARAMETERS = "additionalparameters";

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayload.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayload.kt
@@ -21,6 +21,7 @@ internal class CampaignClassicPushPayload {
     val messageData: MutableMap<String?, String?>
     val messageId: String?
     val deliveryId: String?
+    val trackingInstanceId: String?
     var tag: String?
 
     private val ACC_PAYLOAD_BODY = "_msg"
@@ -67,6 +68,8 @@ internal class CampaignClassicPushPayload {
         if (deliveryId.isNullOrEmpty()) {
             throw IllegalArgumentException("Failed to create CampaignClassicPushPayload, delivery id is null or empty.")
         }
+        trackingInstanceId = remoteMessageData[CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID]
+
 
         this.messageData = remoteMessageData.toMutableMap()
 

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayload.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayload.kt
@@ -70,7 +70,6 @@ internal class CampaignClassicPushPayload {
         }
         trackingInstanceId = remoteMessageData[CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID]
 
-
         this.messageData = remoteMessageData.toMutableMap()
 
         // get the tag from the payload. if no tag was present in the payload use the message id

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushTrackerActivity.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushTrackerActivity.kt
@@ -159,10 +159,12 @@ internal class CampaignClassicPushTrackerActivity : Activity() {
         for (key in extras.keySet()) {
             val value = extras.getString(key)
             if (value != null) {
-                if (key == CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID) {
-                    trackInfo[key] = value
-                } else if (key == CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID) {
-                    trackInfo[key] = value
+                when (key) {
+                    CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID,
+                    CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID,
+                    CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID -> {
+                        trackInfo[key] = value
+                    }
                 }
             }
         }

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/EventExtensions.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/EventExtensions.kt
@@ -78,6 +78,20 @@ internal val Event.deliveryId: String?
         }
     }
 
+internal val Event.trackingInstanceId: String?
+    get() {
+        val trackingInstanceId = DataReader.optString(
+            trackingInfo,
+            CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID,
+            ""
+        )
+        return if (trackingInstanceId.isNullOrBlank()) {
+            null
+        } else {
+            trackingInstanceId
+        }
+    }
+
 /**
  * @return deviceToken [String] from the event data if available and not empty, null otherwise
  */

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManager.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManager.kt
@@ -126,7 +126,7 @@ internal class TrackRequestManager {
         }
         val trackingInstanceId = event.trackingInstanceId
         // create URL
-        val trackEndpoint: String = if(trackingInstanceId.isNullOrEmpty()) {
+        val trackEndpoint: String = if (trackingInstanceId.isNullOrEmpty()) {
             trackingServer
         } else {
             configData.trackingEndpointsMap[trackingInstanceId] ?: trackingServer

--- a/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManager.kt
+++ b/code/campaignclassic/src/main/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManager.kt
@@ -73,15 +73,6 @@ internal class TrackRequestManager {
             return
         }
 
-        val trackingServer = configData.trackingServer ?: run {
-            Log.debug(
-                CampaignClassicConstants.LOG_TAG,
-                SELF_TAG,
-                "handleTrackRequest - Failed to process TrackNotification request, Configuration not available."
-            )
-            return
-        }
-
         val deliveryId = event.deliveryId ?: run {
             Log.debug(
                 CampaignClassicConstants.LOG_TAG,
@@ -125,10 +116,25 @@ internal class TrackRequestManager {
             }
         }
 
+        val trackingServer = configData.trackingServer ?: run {
+            Log.debug(
+                CampaignClassicConstants.LOG_TAG,
+                SELF_TAG,
+                "handleTrackRequest - Failed to process TrackNotification request, Configuration not available."
+            )
+            return
+        }
+        val trackingInstanceId = event.trackingInstanceId
         // create URL
+        val trackEndpoint: String = if(trackingInstanceId.isNullOrEmpty()) {
+            trackingServer
+        } else {
+            configData.trackingEndpointsMap[trackingInstanceId] ?: trackingServer
+        }
+
         val trackUrl = java.lang.String.format(
             CampaignClassicConstants.TRACKING_API_URL_BASE,
-            trackingServer,
+            trackEndpoint,
             messageId,
             deliveryId,
             tagId

--- a/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/AEPMessagingService.java
+++ b/code/campaignclassic/src/phone/java/com/adobe/marketing/mobile/AEPMessagingService.java
@@ -37,6 +37,7 @@ public class AEPMessagingService {
     static final String SELF_TAG = "AEPMessagingService";
     static final String TRACK_INFO_KEY_MESSAGE_ID = "_mId";
     static final String TRACK_INFO_KEY_DELIVERY_ID = "_dId";
+    static final String TRACK_INFO_KEY_TRACKING_INSTANCE_ID = "_iNm";
 
     /**
      * Builds an {@link CampaignClassicPushPayload} then constructs a {@link Notification} using the
@@ -105,6 +106,7 @@ public class AEPMessagingService {
                     {
                         put(TRACK_INFO_KEY_MESSAGE_ID, payload.getMessageId());
                         put(TRACK_INFO_KEY_DELIVERY_ID, payload.getDeliveryId());
+                        put(TRACK_INFO_KEY_TRACKING_INSTANCE_ID, payload.getTrackingInstanceId());
                     }
                 };
         CampaignClassic.trackNotificationReceive(trackInfo);

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfigurationTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfigurationTests.kt
@@ -111,6 +111,29 @@ class CampaignClassicConfigurationTests {
         Assert.assertEquals("https://ep2.com", config.trackingEndpointsMap["inst2"])
     }
 
+    /**
+     * Array elements that are not JSON objects: optJSONObject(i) is null;
+     */
+    @Test
+    fun trackingEndpointsMap_ArrayOfPrimitives_EmptyMap() {
+        setConfigurationSharedState(trackingEndpointsMapping = "[1,2,3]")
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertTrue(config.trackingEndpointsMap.isEmpty())
+    }
+
+    @Test
+    fun trackingEndpointsMap_MixedObjectsAndPrimitives_ParsesOnlyObjects() {
+        val mappingJson = """[1,"x",{"identifier":"ok","endpoint":"https://ok.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertEquals(1, config.trackingEndpointsMap.size)
+        Assert.assertEquals("https://ok.com", config.trackingEndpointsMap["ok"])
+    }
+
     private fun setConfigurationSharedState(trackingEndpointsMapping: String? = null) {
         val configMap = mutableMapOf<String, Any?>(
             CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER to "defaultServer"

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfigurationTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicConfigurationTests.kt
@@ -1,0 +1,130 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.campaignclassic.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import com.adobe.marketing.mobile.ExtensionApi
+import com.adobe.marketing.mobile.SharedStateResult
+import com.adobe.marketing.mobile.SharedStateStatus
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class CampaignClassicConfigurationTests {
+
+    private lateinit var extensionApi: ExtensionApi
+    private lateinit var event: Event
+
+    @Before
+    fun setup() {
+        extensionApi = Mockito.mock(ExtensionApi::class.java)
+        event = Event.Builder("Test", EventType.CAMPAIGN, EventSource.REQUEST_CONTENT).build()
+    }
+
+    // =================================================================================================================
+    // trackingEndpointsMap
+    // =================================================================================================================
+
+    @Test
+    fun trackingEndpointsMap_ValidJsonArray_ReturnsCorrectMap() {
+        val mappingJson = """[{"identifier":"inst1","endpoint":"https://ep1.com"},{"identifier":"inst2","endpoint":"https://ep2.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertEquals(2, config.trackingEndpointsMap.size)
+        Assert.assertEquals("https://ep1.com", config.trackingEndpointsMap["inst1"])
+        Assert.assertEquals("https://ep2.com", config.trackingEndpointsMap["inst2"])
+    }
+
+    @Test
+    fun trackingEndpointsMap_NullMapping_ReturnsEmptyMap() {
+        setConfigurationSharedState(trackingEndpointsMapping = null)
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertTrue(config.trackingEndpointsMap.isEmpty())
+    }
+
+    @Test
+    fun trackingEndpointsMap_BlankMapping_ReturnsEmptyMap() {
+        setConfigurationSharedState(trackingEndpointsMapping = "")
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertTrue(config.trackingEndpointsMap.isEmpty())
+    }
+
+    @Test
+    fun trackingEndpointsMap_MalformedJson_ReturnsEmptyMap() {
+        setConfigurationSharedState(trackingEndpointsMapping = "not valid json [[{")
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertTrue(config.trackingEndpointsMap.isEmpty())
+    }
+
+    @Test
+    fun trackingEndpointsMap_EmptyArray_ReturnsEmptyMap() {
+        setConfigurationSharedState(trackingEndpointsMapping = "[]")
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertTrue(config.trackingEndpointsMap.isEmpty())
+    }
+
+    @Test
+    fun trackingEndpointsMap_ObjectWithMissingIdentifier_SkipsEntry() {
+        val mappingJson = """[{"endpoint":"https://ep1.com"},{"identifier":"inst2","endpoint":"https://ep2.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertEquals(1, config.trackingEndpointsMap.size)
+        Assert.assertEquals("https://ep2.com", config.trackingEndpointsMap["inst2"])
+    }
+
+    @Test
+    fun trackingEndpointsMap_ObjectWithMissingEndpoint_SkipsEntry() {
+        val mappingJson = """[{"identifier":"inst1"},{"identifier":"inst2","endpoint":"https://ep2.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        val config = CampaignClassicConfiguration(event, extensionApi)
+
+        Assert.assertEquals(1, config.trackingEndpointsMap.size)
+        Assert.assertEquals("https://ep2.com", config.trackingEndpointsMap["inst2"])
+    }
+
+    private fun setConfigurationSharedState(trackingEndpointsMapping: String? = null) {
+        val configMap = mutableMapOf<String, Any?>(
+            CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER to "defaultServer"
+        )
+        if (trackingEndpointsMapping != null) {
+            configMap[CampaignClassicConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = trackingEndpointsMapping
+        }
+        Mockito.`when`(
+            extensionApi.getSharedState(
+                ArgumentMatchers.eq(CampaignClassicConstants.EventDataKeys.Configuration.EXTENSION_NAME),
+                ArgumentMatchers.any(),
+                ArgumentMatchers.anyBoolean(),
+                ArgumentMatchers.any()
+            )
+        ).thenReturn(SharedStateResult(SharedStateStatus.SET, configMap))
+    }
+}

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayloadTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayloadTests.kt
@@ -1,0 +1,74 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.campaignclassic.internal
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class CampaignClassicPushPayloadTests {
+
+    // =================================================================================================================
+    // trackingInstanceId (_iNm) parsing
+    // =================================================================================================================
+
+    @Test
+    fun constructor_WithTrackingInstanceId_SetsTrackingInstanceId() {
+        val data = minimalPayloadData().apply {
+            put(CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID, "instance1")
+        }
+
+        val payload = CampaignClassicPushPayload(data)
+
+        Assert.assertEquals("instance1", payload.trackingInstanceId)
+    }
+
+    @Test
+    fun constructor_WithoutTrackingInstanceId_TrackingInstanceIdIsNull() {
+        val data = minimalPayloadData()
+
+        val payload = CampaignClassicPushPayload(data)
+
+        Assert.assertNull(payload.trackingInstanceId)
+    }
+
+    @Test
+    fun constructor_WithEmptyTrackingInstanceId_StoresEmptyString() {
+        val data = minimalPayloadData().apply {
+            put(CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID, "")
+        }
+
+        val payload = CampaignClassicPushPayload(data)
+
+        Assert.assertEquals("", payload.trackingInstanceId)
+    }
+
+    @Test
+    fun constructor_WithBlankTrackingInstanceId_StoresAsIs() {
+        val data = minimalPayloadData().apply {
+            put(CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID, "  ")
+        }
+
+        val payload = CampaignClassicPushPayload(data)
+
+        Assert.assertEquals("  ", payload.trackingInstanceId)
+    }
+
+    private fun minimalPayloadData(): MutableMap<String, String> {
+        return mutableMapOf(
+            CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to "msg123",
+            CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to "del456"
+        )
+    }
+}

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayloadTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicPushPayloadTests.kt
@@ -11,13 +11,132 @@
 
 package com.adobe.marketing.mobile.campaignclassic.internal
 
+import com.adobe.marketing.mobile.notificationbuilder.PushTemplateConstants
+import com.google.firebase.messaging.RemoteMessage
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner.Silent::class)
 class CampaignClassicPushPayloadTests {
+
+    // =================================================================================================================
+    // Map constructor validation and error scenarios
+    // =================================================================================================================
+
+    @Test
+    fun constructor_NullRemoteMessageData_Throws() {
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            @Suppress("USELESS_CAST")
+            CampaignClassicPushPayload(null as Map<String, String>?)
+        }
+    }
+
+    @Test
+    fun constructor_EmptyRemoteMessageData_Throws() {
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            CampaignClassicPushPayload(emptyMap())
+        }
+    }
+
+    @Test
+    fun constructor_MissingMessageId_Throws() {
+        val data = mutableMapOf(
+            CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to "d1"
+        )
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            CampaignClassicPushPayload(data)
+        }
+    }
+
+    @Test
+    fun constructor_MissingDeliveryId_Throws() {
+        val data = mutableMapOf(
+            CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to "m1"
+        )
+        Assert.assertThrows(IllegalArgumentException::class.java) {
+            CampaignClassicPushPayload(data)
+        }
+    }
+
+    @Test
+    fun constructor_WithTagInPayload_UsesTagFromData() {
+        val data = minimalPayloadData().apply {
+            put(PushTemplateConstants.PushPayloadKeys.TAG, "myTag")
+        }
+        val payload = CampaignClassicPushPayload(data)
+        Assert.assertEquals("myTag", payload.tag)
+        Assert.assertEquals("myTag", payload.messageData[PushTemplateConstants.PushPayloadKeys.TAG])
+    }
+
+    @Test
+    fun constructor_WithoutTag_UsesMessageIdAsTag() {
+        val payload = CampaignClassicPushPayload(minimalPayloadData())
+        Assert.assertEquals("msg123", payload.tag)
+        Assert.assertEquals("msg123", payload.messageData[PushTemplateConstants.PushPayloadKeys.TAG])
+    }
+
+    @Test
+    fun constructor_MsgKeyCopiedToBodyWhenBodyMissing() {
+        val data = minimalPayloadData().apply {
+            put("_msg", "bodyFromMsg")
+        }
+        val payload = CampaignClassicPushPayload(data)
+        Assert.assertEquals("bodyFromMsg", payload.messageData[PushTemplateConstants.PushPayloadKeys.BODY])
+    }
+
+    // =================================================================================================================
+    // RemoteMessage constructor (property init)
+    // =================================================================================================================
+
+    @Test
+    fun constructor_FromRemoteMessage_DataOnly_DelegatesToMapConstructor() {
+        val rm = Mockito.mock(RemoteMessage::class.java)
+        Mockito.`when`(rm.data).thenReturn(HashMap(minimalPayloadData()))
+        Mockito.`when`(rm.notification).thenReturn(null)
+
+        val payload = CampaignClassicPushPayload(rm)
+
+        Assert.assertEquals("msg123", payload.messageId)
+        Assert.assertEquals("del456", payload.deliveryId)
+    }
+
+    /**
+     * Map constructor runs before [convertNotificationPayloadData]. If data has no TAG, tag is set to
+     * messageId there, so notification.tag is never applied (TAG is no longer empty when merging).
+     */
+    @Test
+    fun constructor_FromRemoteMessage_WithNotification_TagDefaultsToMessageIdBeforeNotificationMerge() {
+        val data = HashMap(minimalPayloadData())
+        data.remove(PushTemplateConstants.PushPayloadKeys.TAG)
+        val rm = Mockito.mock(RemoteMessage::class.java)
+        Mockito.`when`(rm.data).thenReturn(data)
+        val notif = Mockito.mock(RemoteMessage.Notification::class.java)
+        Mockito.`when`(notif.tag).thenReturn("notifTag")
+        Mockito.`when`(rm.notification).thenReturn(notif)
+
+        val payload = CampaignClassicPushPayload(rm)
+
+        Assert.assertEquals("msg123", payload.tag)
+    }
+
+    @Test
+    fun constructor_FromRemoteMessage_WithNotification_MergesBodyWhenDataBodyEmpty() {
+        val data = HashMap(minimalPayloadData())
+        data.remove(PushTemplateConstants.PushPayloadKeys.BODY)
+        data.remove("_msg")
+        val rm = Mockito.mock(RemoteMessage::class.java)
+        Mockito.`when`(rm.data).thenReturn(data)
+        val notif = Mockito.mock(RemoteMessage.Notification::class.java)
+        Mockito.`when`(notif.body).thenReturn("bodyFromNotification")
+        Mockito.`when`(rm.notification).thenReturn(notif)
+
+        val payload = CampaignClassicPushPayload(rm)
+
+        Assert.assertEquals("bodyFromNotification", payload.messageData[PushTemplateConstants.PushPayloadKeys.BODY])
+    }
 
     // =================================================================================================================
     // trackingInstanceId (_iNm) parsing

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -55,6 +55,7 @@ final class CampaignClassicTestConstants {
             static final String TRACK_INFO = "trackinfo";
             static final String TRACK_INFO_KEY_MESSAGE_ID = "_mId";
             static final String TRACK_INFO_KEY_DELIVERY_ID = "_dId";
+            static final String TRACK_INFO_KEY_TRACKING_INSTANCE_ID = "_iNm";
             static final String DEVICE_TOKEN = "devicetoken";
             static final String USER_KEY = "userkey";
             static final String ADDITIONAL_PARAMETERS = "additionalparameters";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/CampaignClassicTestConstants.java
@@ -41,6 +41,8 @@ final class CampaignClassicTestConstants {
             static final String CAMPAIGNCLASSIC_MARKETING_SERVER =
                     "campaignclassic.marketingServer";
             static final String CAMPAIGNCLASSIC_TRACKING_SERVER = "campaignclassic.trackingServer";
+            static final String CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING =
+                    "campaignclassic.trackingEndpointsMapping";
             static final String CAMPAIGNCLASSIC_APP_INTEGRATION_KEY =
                     "campaignclassic.android.integrationKey";
             static final String CAMPAIGNCLASSIC_TIMEOUT = "campaignclassic.timeout";

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/EventExtensionsTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/EventExtensionsTests.kt
@@ -1,0 +1,58 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.campaignclassic.internal
+
+import com.adobe.marketing.mobile.Event
+import com.adobe.marketing.mobile.EventSource
+import com.adobe.marketing.mobile.EventType
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner.Silent::class)
+class EventExtensionsTests {
+
+    @Test
+    fun trackingInstanceId_NonBlank_ReturnsValue() {
+        val event = eventWithTrackInfo(
+            mapOf(
+                CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID to "instanceA"
+            )
+        )
+
+        Assert.assertEquals("instanceA", event.trackingInstanceId)
+    }
+
+    @Test
+    fun trackingInstanceId_BlankOrMissing_ReturnsNull() {
+        val eventBlank = eventWithTrackInfo(
+            mapOf(
+                CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID to "   "
+            )
+        )
+        Assert.assertNull(eventBlank.trackingInstanceId)
+
+        val eventMissing = eventWithTrackInfo(emptyMap())
+        Assert.assertNull(eventMissing.trackingInstanceId)
+    }
+
+    private fun eventWithTrackInfo(trackInfo: Map<String, String>): Event {
+        return Event.Builder("t", EventType.CAMPAIGN, EventSource.REQUEST_CONTENT)
+            .setEventData(
+                mapOf(
+                    CampaignClassicConstants.EventDataKeys.CampaignClassic.TRACK_INFO to trackInfo
+                )
+            )
+            .build()
+    }
+}

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
@@ -195,9 +195,9 @@ class TrackRequestManagerTests {
         // setup
         setConfigurationSharedState()
 
-        // test
+        // test: explicitly null track info (backwards compat - no track info in event)
         trackManager.handleTrackRequest(
-            getTrackRequestEvent(trackInfo = null),
+            getTrackRequestEvent(trackInfo = null, useExplicitTrackInfo = true),
             CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
         )
 
@@ -210,9 +210,9 @@ class TrackRequestManagerTests {
         // setup
         setConfigurationSharedState()
 
-        // test
+        // test: explicitly empty track info (backwards compat)
         trackManager.handleTrackRequest(
-            getTrackRequestEvent(trackInfo = emptyMap()),
+            getTrackRequestEvent(trackInfo = emptyMap(), useExplicitTrackInfo = true),
             CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
         )
 
@@ -530,14 +530,110 @@ class TrackRequestManagerTests {
     }
 
     // =================================================================================================================
+    // Tracking server selection by trackingInstanceId (_iNm) and backwards compatibility
+    // =================================================================================================================
+    //
+    // Backwards compatibility:
+    // - Null/empty track info: handleTrackRequest_NullTrackInfo, handleTrackRequest_EmptyTrackInfo (no network call).
+    // - Legacy payload without _iNm: handleTrackRequest_UsesTrackingServer_WhenTrackingInstanceIdIsNull (uses default trackingServer).
+    // - Config without trackingEndpointsMapping: handleTrackRequest_UsesTrackingServer_WhenTrackingEndpointsMapEmpty (fallback to trackingServer).
+    // - Unknown instance id: handleTrackRequest_UsesTrackingServer_WhenTrackingInstanceIdNotInMap (fallback to trackingServer).
+
+    @Test
+    fun handleTrackRequest_UsesTrackingServer_WhenTrackingInstanceIdIsNull() {
+        setConfigurationSharedState()
+
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(trackingInstanceId = null),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+        Assert.assertEquals("https://testTrackingServer/r/?id=h3039,testDeliveryId,2", networkRequestCaptor.value.url)
+    }
+
+    @Test
+    fun handleTrackRequest_UsesTrackingServer_WhenTrackingInstanceIdIsEmpty() {
+        setConfigurationSharedState()
+
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(trackingInstanceId = ""),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+        Assert.assertEquals("https://testTrackingServer/r/?id=h3039,testDeliveryId,2", networkRequestCaptor.value.url)
+    }
+
+    @Test
+    fun handleTrackRequest_UsesEndpointFromMap_WhenTrackingInstanceIdInMap() {
+        val mappingJson = """[{"identifier":"instance1","endpoint":"custom.endpoint.com"},{"identifier":"instance2","endpoint":"other.endpoint.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(trackingInstanceId = "instance1"),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+        Assert.assertEquals("https://custom.endpoint.com/r/?id=h3039,testDeliveryId,2", networkRequestCaptor.value.url)
+    }
+
+    @Test
+    fun handleTrackRequest_UsesTrackingServer_WhenTrackingInstanceIdNotInMap() {
+        val mappingJson = """[{"identifier":"instance1","endpoint":"custom.endpoint.com"}]"""
+        setConfigurationSharedState(trackingEndpointsMapping = mappingJson)
+
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(trackingInstanceId = "unknownInstance"),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+        Assert.assertEquals("https://testTrackingServer/r/?id=h3039,testDeliveryId,2", networkRequestCaptor.value.url)
+    }
+
+    @Test
+    fun handleTrackRequest_UsesTrackingServer_WhenTrackingEndpointsMapEmpty() {
+        setConfigurationSharedState(trackingEndpointsMapping = null)
+
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(trackingInstanceId = "instance1"),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+
+        val networkRequestCaptor = ArgumentCaptor.forClass(NetworkRequest::class.java)
+        Mockito.verify(networkService, Mockito.times(1))
+            .connectAsync(networkRequestCaptor.capture(), ArgumentMatchers.any())
+        Assert.assertEquals("https://testTrackingServer/r/?id=h3039,testDeliveryId,2", networkRequestCaptor.value.url)
+    }
+
+    // =================================================================================================================
     // private methods
     // =================================================================================================================
 
     private fun setConfigurationSharedState(
         trackingServer: String? = "testTrackingServer",
         privacyStatus: MobilePrivacyStatus = MobilePrivacyStatus.OPT_IN,
-        timeout: Int = CampaignClassicTestConstants.DEFAULT_TIMEOUT
+        timeout: Int = CampaignClassicTestConstants.DEFAULT_TIMEOUT,
+        trackingEndpointsMapping: String? = null
     ) {
+        val configMap = mutableMapOf<String, Any?>(
+            CampaignClassicTestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER to trackingServer,
+            CampaignClassicTestConstants.EventDataKeys.Configuration.GLOBAL_CONFIG_PRIVACY to privacyStatus.value,
+            CampaignClassicTestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TIMEOUT to timeout
+        )
+        if (trackingEndpointsMapping != null) {
+            configMap[CampaignClassicTestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_ENDPOINT_MAPPING] = trackingEndpointsMapping
+        }
         Mockito.`when`(
             extensionApi.getSharedState(
                 ArgumentMatchers.eq(CampaignClassicTestConstants.EventDataKeys.Configuration.EXTENSION_NAME),
@@ -545,33 +641,40 @@ class TrackRequestManagerTests {
                 ArgumentMatchers.anyBoolean(),
                 ArgumentMatchers.any()
             )
-        ).thenReturn(
-            SharedStateResult(
-                SharedStateStatus.SET,
-                mapOf(
-                    CampaignClassicTestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TRACKING_SERVER to trackingServer,
-                    CampaignClassicTestConstants.EventDataKeys.Configuration.GLOBAL_CONFIG_PRIVACY to privacyStatus.value,
-                    CampaignClassicTestConstants.EventDataKeys.Configuration.CAMPAIGNCLASSIC_TIMEOUT to timeout
-                )
-            )
-        )
+        ).thenReturn(SharedStateResult(SharedStateStatus.SET, configMap))
     }
 
+    /**
+     * Builds a track request event.
+     * When [useExplicitTrackInfo] is false (default), [trackInfo] is ignored and a default map is built from
+     * [messageId], [deliveryId], and optionally [trackingInstanceId]. Use this for normal "has track info" cases.
+     * When [useExplicitTrackInfo] is true, [trackInfo] is used as-is (may be null or empty) for backwards-compat
+     * tests that verify behaviour when track info is missing.
+     */
+    @OptIn(ExperimentalStdlibApi::class)
     private fun getTrackRequestEvent(
         messageId: String? = "12345",
         deliveryId: String? = "testDeliveryId",
-        trackingInstanceId: String? = "1",
-        trackInfo: Map<String, String?>? = mapOf(
-            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to messageId,
-            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to deliveryId,
-            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID to trackingInstanceId
-        )
+        trackingInstanceId: String? = null,
+        trackInfo: Map<String, String?>? = null,
+        useExplicitTrackInfo: Boolean = false
     ): Event {
+        val info = if (useExplicitTrackInfo) {
+            trackInfo
+        } else {
+            buildMap {
+                put(CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID, messageId)
+                put(CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID, deliveryId)
+                if (trackingInstanceId != null) {
+                    put(CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID, trackingInstanceId)
+                }
+            }
+        }
         return Event.Builder("Track Request", EventType.CAMPAIGN, EventSource.REQUEST_CONTENT)
             .setEventData(
                 mapOf(
                     CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_RECEIVE to true,
-                    CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO to trackInfo
+                    CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO to info
                 )
             )
             .build()

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
@@ -560,9 +560,11 @@ class TrackRequestManagerTests {
     private fun getTrackRequestEvent(
         messageId: String? = "12345",
         deliveryId: String? = "testDeliveryId",
+        trackingInstanceId: String? = "1",
         trackInfo: Map<String, String?>? = mapOf(
             CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_MESSAGE_ID to messageId,
-            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to deliveryId
+            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_DELIVERY_ID to deliveryId,
+            CampaignClassicTestConstants.EventDataKeys.CampaignClassic.TRACK_INFO_KEY_TRACKING_INSTANCE_ID to trackingInstanceId
         )
     ): Event {
         return Event.Builder("Track Request", EventType.CAMPAIGN, EventSource.REQUEST_CONTENT)

--- a/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
+++ b/code/campaignclassic/src/test/java/com/adobe/marketing/mobile/campaignclassic/internal/TrackRequestManagerTests.kt
@@ -297,6 +297,41 @@ class TrackRequestManagerTests {
     }
 
     @Test
+    fun handleTrackRequest_MessageIdNegativeWithNonDigitSuffix_NoNetwork() {
+        setConfigurationSharedState()
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "-12ab34"),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+        Mockito.verifyNoInteractions(networkService)
+    }
+
+    @Test
+    fun handleTrackRequest_MessageIdSingleMinus_NoNetwork() {
+        setConfigurationSharedState()
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(messageId = "-"),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+        Mockito.verifyNoInteractions(networkService)
+    }
+
+    @Test
+    fun handleTrackRequest_NetworkCallbackWithNullConnection_DoesNotCrash() {
+        setConfigurationSharedState()
+        Mockito.`when`(networkService.connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any()))
+            .thenAnswer { invocation ->
+                (invocation.arguments[1] as NetworkCallback).call(null)
+                null
+            }
+        trackManager.handleTrackRequest(
+            getTrackRequestEvent(),
+            CampaignClassicTestConstants.MESSAGE_CLICKED_TAGID
+        )
+        Mockito.verify(networkService, Mockito.times(1)).connectAsync(ArgumentMatchers.any(), ArgumentMatchers.any())
+    }
+
+    @Test
     fun handleTrackRequest_TrackInfoNullMessageIdKey() {
         // setup
         setConfigurationSharedState()

--- a/code/testapp/src/main/java/com/adobe/campaignclassictestapp/MainActivity.java
+++ b/code/testapp/src/main/java/com/adobe/campaignclassictestapp/MainActivity.java
@@ -28,6 +28,7 @@ public class MainActivity extends AppCompatActivity {
 	private static String LOG_TAG = "MainActivity";
 	private static String DELIVERYID = "_dId";
 	private static String MESSAGEID = "_mId";
+	private static String TRACKING_INSTANCE_ID = "_iNm";
 	private TextView notificationPermission;
 
 	@Override
@@ -73,6 +74,8 @@ public class MainActivity extends AppCompatActivity {
 				if (key.equals(MESSAGEID)) {
 					trackInfo.put(key, value.toString());
 				} else if (key.equals(DELIVERYID)) {
+					trackInfo.put(key, value.toString());
+				} else if (key.equals(TRACKING_INSTANCE_ID)) {
 					trackInfo.put(key, value.toString());
 				}
 			}

--- a/code/testapp/src/main/java/com/adobe/campaignclassictestapp/NotificationService.java
+++ b/code/testapp/src/main/java/com/adobe/campaignclassictestapp/NotificationService.java
@@ -30,6 +30,7 @@ public class NotificationService extends FirebaseMessagingService {
 	private static String LOG_TAG = "NotificationService";
 	private static String DELIVERYID = "_dId";
 	private static String MESSAGEID = "_mId";
+	private static String TRACKING_INSTANCE_ID = "_iNm";
 	private static String NOTIFICATION_TEXT = "notificationText";
 	private static String NOTIFICATION_URL = "NotificationUrl";
 
@@ -67,9 +68,11 @@ public class NotificationService extends FirebaseMessagingService {
 		String url = payloadData.get("url");
 		String messageId = payloadData.get(MESSAGEID);
 		String deliveryId = payloadData.get(DELIVERYID);
+		String trackingInstanceId = payloadData.get(TRACKING_INSTANCE_ID);
 		Map<String, String> trackInfo = new HashMap<>();
 		trackInfo.put(MESSAGEID, messageId);
 		trackInfo.put(DELIVERYID, deliveryId);
+		trackInfo.put(TRACKING_INSTANCE_ID, trackingInstanceId);
 		CampaignClassic.trackNotificationReceive(trackInfo);
 
 
@@ -92,6 +95,7 @@ public class NotificationService extends FirebaseMessagingService {
 		intent.putExtra(NOTIFICATION_URL, url);
 		intent.putExtra(DELIVERYID, deliveryId);
 		intent.putExtra(MESSAGEID, messageId);
+		intent.putExtra(TRACKING_INSTANCE_ID, trackingInstanceId);
 		intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
 		PendingIntent pendingIntent;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
These changes will allow SDK to take leverage of updated configuration settings which map multiple tracking endpoints. Allowing user to track notification interactions on multiple RT and Marketting servers at a time.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
